### PR TITLE
Test Python 3.4-3.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
-sudo: required
+language: python
+python:
+  - 3.6
+  - 3.5
+  - 3.4
 
-services:
-  - docker
-
-before_install:
-  - make build-docker-image
+install:
+  - make install
 
 script:
-  - make ci-docker
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ python:
   - 3.5
   - 3.4
 
+env:
+  global:
+    - MPLBACKEND=agg
+
 install:
   - make install
 


### PR DESCRIPTION
This would have caught my mistake that led to #23 .

As a side effect, tests also run faster, so long as Travis has enough free workers to run them concurrently.

I don't think we gain anything from defining a docker container with pip and pytest for this. Travis already has those things. I'd like to get rid of the Dockerfile from this repo.