### PR TITLE
Add methods to get labelled array objects

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -35,6 +35,8 @@ including the main detectors, record data more frequently.
 
    .. automethod:: get_series
 
+   .. automethod:: get_array
+
 
 .. autoclass:: H5File
 
@@ -61,3 +63,5 @@ including the main detectors, record data more frequently.
    .. automethod:: get_dataframe
 
    .. automethod:: get_series
+
+   .. automethod:: get_array

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -384,6 +384,10 @@ class H5File:
         key: str
             Key of parameter within that device, e.g. "beamPosition.iyPos.value"
             or "header.linkId". The data must be 1D in the file.
+        extra_dims: list of str
+            Name extra dimensions in the array. The first dimension is
+            automatically called 'train'. The default for extra dimensions
+            is dim_0, dim_1, ...
         """
         name = self._make_field_name(device, key)
 
@@ -659,6 +663,10 @@ class RunDirectory:
         key: str
             Key of parameter within that device, e.g. "beamPosition.iyPos.value"
             or "header.linkId". The data must be 1D in the file.
+        extra_dims: list of str
+            Name extra dimensions in the array. The first dimension is
+            automatically called 'train'. The default for extra dimensions
+            is dim_0, dim_1, ...
         """
         seq_arrays = [f.get_array(device, key, extra_dims=extra_dims)
                       for f in self.files

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -675,7 +675,7 @@ class RunDirectory:
                       for f in self.files
                       if device in (f.control_sources | f.instrument_sources)]
 
-        return xr.concat(sorted(seq_arrays, key=lambda a: a.coords['train'][0]),
+        return xr.concat(sorted(seq_arrays, key=lambda a: a.coords['trainId'][0]),
                          dim='trainId')
 
     def _assemble_sequences(self):

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -375,6 +375,9 @@ class H5File:
     def get_array(self, device, key, extra_dims=None):
         """Return a labelled array for a particular data field.
 
+        The first axis of the returned data will be the train IDs.
+        Datasets which are per-pulse in the first dimension are not supported.
+
         Parameters
         ----------
 
@@ -651,8 +654,8 @@ class RunDirectory:
     def get_array(self, device, key, extra_dims=None):
         """Return a labelled array for a particular data field.
 
-        The data is loaded into memory, which might cause problems when working
-        with very large datasets, such as the main detector data.
+        The first axis of the returned data will be the train IDs.
+        Datasets which are per-pulse in the first dimension are not supported.
 
         Parameters
         ----------

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -415,7 +415,7 @@ class H5File:
             index = index_ds[index_ds[:] != 0]
             data = ds[index_ds[:] != 0, ...]
             if len(np.unique(index)) != len(index):
-                raise ValueError("Train IDs are not unique for %s" % data_src)
+                raise ValueError("%s has more than one data point per train" % data_src)
         else:
             raise ValueError("Unknown data source %r" % data_src)
 

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -412,17 +412,14 @@ class H5File:
             index = index_ds[index_ds[:] != 0]
             data = ds[index_ds[:] != 0, ...]
             if len(np.unique(index)) != len(index):
-                pulse_id = self.file['/{}/pulseId'.format(data_src)]
-                pulse_id = pulse_id[index_ds[:] != 0]
-                index = pd.MultiIndex.from_arrays([index, pulse_id],
-                                                  names=['trainId', 'pulseId'])
+                raise ValueError("Train IDs are not unique for %s" % data_src)
         else:
             raise ValueError("Unknown data source %r" % data_src)
 
         if extra_dims is None:
             extra_dims = ['dim_%d' % i for i in range(data.ndim - 1)]
-        dims = ['train'] + extra_dims
-        return xr.DataArray(data, dims=dims, coords={'train': index})
+        dims = ['trainId'] + extra_dims
+        return xr.DataArray(data, dims=dims, coords={'trainId': index})
 
     def close(self):
         self.file.close()

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -616,17 +616,8 @@ class RunDirectory:
             Key of parameter within that device, e.g. "beamPosition.iyPos.value"
             or "header.linkId". The data must be 1D in the file.
         """
-        name = device + '/' + key
-        if name.endswith('.value'):
-            name = name[:-6]
-
-        # Find the data
-        find_device = device
-        if ':' in find_device:  # INSTRUMENT data
-            find_device += '/' + key.split('.')[0]
-
         seq_series = [f.get_series(device, key) for f in self.files
-                      if find_device in (f.control_sources | f.instrument_sources)]
+                      if device in (f.control_sources | f.instrument_sources)]
 
         return pd.concat(sorted(seq_series, key=lambda s: s.index[0]))
 

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -654,6 +654,9 @@ class RunDirectory:
     def get_array(self, device, key, extra_dims=None):
         """Return a labelled array for a particular data field.
 
+        The data is loaded into memory, which might cause problems when working
+        with very large datasets, such as the main detector data.
+
         Parameters
         ----------
 

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -673,7 +673,7 @@ class RunDirectory:
                       if device in (f.control_sources | f.instrument_sources)]
 
         return xr.concat(sorted(seq_arrays, key=lambda a: a.coords['train'][0]),
-                         dim='train')
+                         dim='trainId')
 
     def _assemble_sequences(self):
         """Assemble the sequences for each data recorder.

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -168,7 +168,7 @@ def test_file_get_array(mock_fxe_control_data):
         arr = f.get_array('FXE_XAD_GEC/CAM/CAMERA:daqOutput', 'data.image.pixels')
 
     assert isinstance(arr, DataArray)
-    assert arr.dims == ('train', 'dim_0', 'dim_1')
+    assert arr.dims == ('trainId', 'dim_0', 'dim_1')
     assert arr.shape == (400, 255, 1024)
     assert arr.coords['train'][0] == 10000
 
@@ -178,6 +178,6 @@ def test_run_get_array(mock_fxe_run):
                         extra_dims=['pulse'])
 
     assert isinstance(arr, DataArray)
-    assert arr.dims == ('train', 'pulse')
+    assert arr.dims == ('trainId', 'pulse')
     assert arr.shape == (480, 1000)
     assert arr.coords['train'][0] == 10000

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -170,7 +170,7 @@ def test_file_get_array(mock_fxe_control_data):
     assert isinstance(arr, DataArray)
     assert arr.dims == ('trainId', 'dim_0', 'dim_1')
     assert arr.shape == (400, 255, 1024)
-    assert arr.coords['train'][0] == 10000
+    assert arr.coords['trainId'][0] == 10000
 
 def test_run_get_array(mock_fxe_run):
     run = RunDirectory(mock_fxe_run)
@@ -180,4 +180,4 @@ def test_run_get_array(mock_fxe_run):
     assert isinstance(arr, DataArray)
     assert arr.dims == ('trainId', 'pulse')
     assert arr.shape == (480, 1000)
-    assert arr.coords['train'][0] == 10000
+    assert arr.coords['trainId'][0] == 10000

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(name="karabo_data",
           'pandas; python_version>="3.5"',
           'pandas<0.21; python_version<"3.5"',
           'pyzmq>=17.0.0',
+          'xarray',
       ],
       extras_require={
           'docs': [


### PR DESCRIPTION
While working on an example use case Hans sent me, I found that accessing the data train-by-train was very slow. So I added some methods to get a field at a time, as a labelled array. This is similar to the methods I already added to get a pandas series, but it handles multidimensional data using [xarray](https://xarray.pydata.org/en/stable/).

* The advantage of the labelled array over plain numpy arrays is that it makes it easy to align data by train IDs: `xarray.align(arr1, arr2, join='inner')` will return arrays with only the trains that are in both. It also lets you do things like `arr.mean('train')` to average along the train axis.
* Labelled arrays are, naturally, based on numpy arrays, so you can do anything you would do with a numpy array.
* This loads all the requested data into memory. On Maxwell, that should be OK for most data except big detector data.
* Like the other methods, `.get_array()` exists both on file objects and on a run directory. The run directory method concatenates arrays from several sequence files.
* Future extension: retrieve a [DataSet](http://xarray.pydata.org/en/stable/data-structures.html#dataset), xarray's multidimensional equivalent to a pandas DataFrame.