### PR TITLE
Smoketest hdf5_file_info()

### DIFF
--- a/karabo_data/tests/conftest.py
+++ b/karabo_data/tests/conftest.py
@@ -1,0 +1,40 @@
+import os.path as osp
+import pytest
+from tempfile import TemporaryDirectory
+from . import make_examples
+
+@pytest.fixture(scope='module')
+def mock_agipd_data():
+    # This one uses the older index format
+    # (first/last/status instead of first/count)
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'CORR-R9999-AGIPD07-S00000.h5')
+        make_examples.make_agipd_example_file(path)
+        yield path
+
+@pytest.fixture(scope='module')
+def mock_lpd_data():
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'RAW-R9999-LPD00-S00000.h5')
+        make_examples.make_lpd_file(path)
+        yield path
+
+@pytest.fixture(scope='module')
+def mock_fxe_control_data():
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'RAW-R0450-DA01-S00001.h5')
+        make_examples.make_fxe_da_file(path)
+        yield path
+
+@pytest.fixture(scope='module')
+def mock_spb_control_data_badname():
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'RAW-R0309-DA01-S00000.h5')
+        make_examples.make_data_file_bad_device_name(path)
+        yield path
+
+@pytest.fixture(scope='module')
+def mock_fxe_run():
+    with TemporaryDirectory() as td:
+        make_examples.make_fxe_run(td)
+        yield td

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -1,48 +1,9 @@
 from itertools import islice
-import os.path as osp
 import pandas as pd
-import pytest
-from tempfile import TemporaryDirectory
 from xarray import DataArray
 
 from karabo_data import (H5File, RunDirectory, stack_data, stack_detector_data)
-from . import make_examples
 
-@pytest.fixture(scope='module')
-def mock_agipd_data():
-    # This one uses the older index format
-    # (first/last/status instead of first/count)
-    with TemporaryDirectory() as td:
-        path = osp.join(td, 'CORR-R9999-AGIPD07-S00000.h5')
-        make_examples.make_agipd_example_file(path)
-        yield path
-
-@pytest.fixture(scope='module')
-def mock_lpd_data():
-    with TemporaryDirectory() as td:
-        path = osp.join(td, 'RAW-R9999-AGIPD00-S00000.h5')
-        make_examples.make_lpd_file(path)
-        yield path
-
-@pytest.fixture(scope='module')
-def mock_fxe_control_data():
-    with TemporaryDirectory() as td:
-        path = osp.join(td, 'RAW-R0450-DA01-S00001.h5')
-        make_examples.make_fxe_da_file(path)
-        yield path
-
-@pytest.fixture(scope='module')
-def mock_spb_control_data_badname():
-    with TemporaryDirectory() as td:
-        path = osp.join(td, 'RAW-R0309-DA01-S00000.h5')
-        make_examples.make_data_file_bad_device_name(path)
-        yield path
-
-@pytest.fixture(scope='module')
-def mock_fxe_run():
-    with TemporaryDirectory() as td:
-        make_examples.make_fxe_run(td)
-        yield td
 
 def test_iterate_trains(mock_agipd_data):
     with H5File(mock_agipd_data) as f:

--- a/karabo_data/tests/test_utils.py
+++ b/karabo_data/tests/test_utils.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import subprocess
 
+from karabo_data import utils
 from karabo_data.utils import QuickView
 
 
@@ -82,6 +83,12 @@ def test_init_quick_view():
     with pytest.raises(TypeError) as info:
         qv.data = np.empty((1,1,1,1), dtype=np.int8)
 
+
+def test_hdf5_file_info(mock_lpd_data, capsys):
+    utils.hdf5_file_info([mock_lpd_data])
+
+    out, err = capsys.readouterr()
+    assert "Entries: 480" in out
 
 if __name__ == "__main__":
     pytest.main(["-v"])


### PR DESCRIPTION
This function is a [big red block](https://codecov.io/gh/European-XFEL/karabo_data/src/a60995c12996590233c913df5aa18b145510c518/karabo_data/utils.py#L118) in the coverage at the moment, and it's easy to add a basic test for it.

The other changes are moving some pytest fixtures so that they're accessible to tests outside the `test_reader_mockdata` module.