### PR TITLE
More options for the .trains() method

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -281,7 +281,7 @@ class H5File:
             train_data[device]['metadata'] = {
                 'source': source,
                 'timestamp': ts,
-                'timestamp.tid': int(self.train_ids[train_index]),
+                'timestamp.tid': train_id,
                 'timestamp.sec': sec,
                 'frac': frac,
             }

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -753,7 +753,14 @@ class RunDirectory:
 
             train_data = {}
             for fh in fhs:
-                _, data = fh.train_from_id(tid, devices=devices)
+                if devices is None:
+                    file_selection = None
+                else:
+                    file_selection = {(src, key) for (src, key) in devices
+                        if src in (fh.control_sources | fh.instrument_sources)}
+                    if not file_selection:
+                        continue
+                _, data = fh.train_from_id(tid, devices=file_selection)
                 train_data.update(data)
 
             yield (tid, train_data)

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -61,17 +61,17 @@ class FilenameInfo:
         else:
             self.description = "Unknown data source ({})", datasrc
 
-class _SliceContstructor(type):
+class _SliceConstructor(type):
     """Allows instantiation like subclass[1:5]
     """
     def __getitem__(self, item):
         return self(item)
 
-class by_id(metaclass=_SliceContstructor):
+class by_id(metaclass=_SliceConstructor):
     def __init__(self, value):
         self.value = value
 
-class by_index(metaclass=_SliceContstructor):
+class by_index(metaclass=_SliceConstructor):
     def __init__(self, value):
         self.value = value
 

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -290,7 +290,7 @@ class H5File:
 
         return train_id, train_data
 
-    def trains(self, devices=None, *, train_range=None, partial=True):
+    def trains(self, devices=None, *, train_range=None, require_all=False):
         """Iterate over all trains in the file.
 
         Parameters
@@ -316,9 +316,9 @@ class H5File:
         train_range: range object, optional
             Iterate over only these train IDs.
 
-        partial: bool
-            True (default) returns any data available for the requested trains.
-            False skips trains which don't have all the requested data;
+        require_all: bool
+            False (default) returns any data available for the requested trains.
+            True skips trains which don't have all the requested data;
             this requires that you specify required data using *devices*.
 
         Examples
@@ -354,14 +354,14 @@ class H5File:
 
         if devices:
             devices = _normalize_data_selection(devices, self)
-        elif not partial:
+        elif require_all:
             raise ValueError("Cannot skip partial data without devices= parameter")
 
         for index, tid in enumerate(tids):
             if tid not in train_range:
                 continue
 
-            if (not partial) and self._check_data_missing(devices, tid):
+            if require_all and self._check_data_missing(devices, tid):
                 continue
 
             yield self._gen_train_data(index, only_this=devices)
@@ -718,7 +718,7 @@ class RunDirectory:
             missing = file._check_data_missing(missing, tid)
         return missing
 
-    def trains(self, devices=None, *, train_range=None, partial=True):
+    def trains(self, devices=None, *, train_range=None, require_all=False):
         """Iterate over all trains in the run and gather all sources.
 
         ::
@@ -737,9 +737,9 @@ class RunDirectory:
         train_range: range object, optional
             Iterate over only these train IDs.
 
-        partial: bool
-            True (default) returns any data available for the requested trains.
-            False skips trains which don't have all the requested data;
+        require_all: bool
+            False (default) returns any data available for the requested trains.
+            True skips trains which don't have all the requested data;
             this requires that you specify required data using *devices*.
 
         Yields
@@ -759,14 +759,14 @@ class RunDirectory:
 
         if devices:
             devices = _normalize_data_selection(devices, self)
-        elif not partial:
+        elif require_all:
             raise ValueError("Cannot skip partial data without devices= parameter")
 
         for tid, fhs in self.ordered_trains:
             if tid not in train_range:
                 continue
 
-            if (not partial) and self._check_data_missing(devices, tid, fhs):
+            if require_all and self._check_data_missing(devices, tid, fhs):
                 continue
 
             train_data = {}

--- a/karabo_data/tests/conftest.py
+++ b/karabo_data/tests/conftest.py
@@ -27,6 +27,13 @@ def mock_fxe_control_data():
         yield path
 
 @pytest.fixture(scope='module')
+def mock_sa3_control_data():
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'RAW-R0450-DA01-S00001.h5')
+        make_examples.make_sa3_da_file(path)
+        yield path
+
+@pytest.fixture(scope='module')
 def mock_spb_control_data_badname():
     with TemporaryDirectory() as td:
         path = osp.join(td, 'RAW-R0309-DA01-S00000.h5')

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -64,6 +64,15 @@ def test_iterate_trains_select_keys(mock_fxe_control_data):
             assert 'beamPosition.iyPos.value' not in data['SA1_XTD2_XGM/DOOCS/MAIN']
             assert 'SA3_XTD10_VAC/TSENS/S30160K' not in data
 
+def test_iterate_trains_partial(mock_sa3_control_data):
+    with H5File(mock_sa3_control_data) as f:
+        trains_iter = f.trains(devices=[('*/CAM/BEAMVIEW:daqOutput', 'data.image.dims')], partial=False)
+        tids = [t for (t, _) in trains_iter]
+        assert tids == []
+        trains_iter = f.trains(devices=[('*/CAM/BEAMVIEW:daqOutput', 'data.image.dims')], partial=True)
+        tids = [t for (t, _) in trains_iter]
+        assert tids != []
+
 def test_read_fxe_run(mock_fxe_run):
     run = RunDirectory(mock_fxe_run)
     assert len(run.files) == 18  # 16 detector modules + 2 control data files

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -64,12 +64,12 @@ def test_iterate_trains_select_keys(mock_fxe_control_data):
             assert 'beamPosition.iyPos.value' not in data['SA1_XTD2_XGM/DOOCS/MAIN']
             assert 'SA3_XTD10_VAC/TSENS/S30160K' not in data
 
-def test_iterate_trains_partial(mock_sa3_control_data):
+def test_iterate_trains_require_all(mock_sa3_control_data):
     with H5File(mock_sa3_control_data) as f:
-        trains_iter = f.trains(devices=[('*/CAM/BEAMVIEW:daqOutput', 'data.image.dims')], partial=False)
+        trains_iter = f.trains(devices=[('*/CAM/BEAMVIEW:daqOutput', 'data.image.dims')], require_all=True)
         tids = [t for (t, _) in trains_iter]
         assert tids == []
-        trains_iter = f.trains(devices=[('*/CAM/BEAMVIEW:daqOutput', 'data.image.dims')], partial=True)
+        trains_iter = f.trains(devices=[('*/CAM/BEAMVIEW:daqOutput', 'data.image.dims')], require_all=False)
         tids = [t for (t, _) in trains_iter]
         assert tids != []
 

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -1,5 +1,6 @@
 from itertools import islice
 import pandas as pd
+import pytest
 from xarray import DataArray
 
 from karabo_data import (H5File, RunDirectory, stack_data, stack_detector_data)
@@ -86,6 +87,12 @@ def test_iterate_fxe_run(mock_fxe_run):
     assert 'image.data' in data['FXE_DET_LPD1M-1/DET/15CH0:xtdf']
     assert 'FXE_XAD_GEC/CAM/CAMERA' in data
     assert 'firmwareVersion.value' in data['FXE_XAD_GEC/CAM/CAMERA']
+
+def test_iterate_select_trains(mock_fxe_run):
+    run = RunDirectory(mock_fxe_run)
+
+    tids = [tid for (tid, _) in run.trains(train_range=range(10004, 10006))]
+    assert tids == [10004, 10005]
 
 def test_train_by_id_fxe_run(mock_fxe_run):
     run = RunDirectory(mock_fxe_run)

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -103,6 +103,16 @@ def test_iterate_select_trains(mock_fxe_run):
     tids = [tid for (tid, _) in run.trains(train_range=range(10004, 10006))]
     assert tids == [10004, 10005]
 
+def test_iterate_run_glob_devices(mock_fxe_run):
+    run = RunDirectory(mock_fxe_run)
+    trains_iter = run.trains([("*/DET/*", "image.data")])
+    tid, data = next(trains_iter)
+    assert tid == 10000
+    assert 'FXE_DET_LPD1M-1/DET/15CH0:xtdf' in data
+    assert 'image.data' in data['FXE_DET_LPD1M-1/DET/15CH0:xtdf']
+    assert 'detector.data' not in data['FXE_DET_LPD1M-1/DET/15CH0:xtdf']
+    assert 'FXE_XAD_GEC/CAM/CAMERA' not in data
+
 def test_train_by_id_fxe_run(mock_fxe_run):
     run = RunDirectory(mock_fxe_run)
     _, data = run.train_from_id(10024)

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -3,7 +3,9 @@ import pandas as pd
 import pytest
 from xarray import DataArray
 
-from karabo_data import (H5File, RunDirectory, stack_data, stack_detector_data)
+from karabo_data import (
+    H5File, RunDirectory, stack_data, stack_detector_data, by_index, by_id,
+)
 
 
 def test_iterate_trains(mock_agipd_data):
@@ -46,6 +48,14 @@ def test_iterate_trains_fxe(mock_fxe_control_data):
             assert 'SA1_XTD2_XGM/DOOCS/MAIN' in data.keys()
             assert 'beamPosition.ixPos.value' in data['SA1_XTD2_XGM/DOOCS/MAIN']
 
+
+def test_iterate_file_select_trains(mock_fxe_control_data):
+    with H5File(mock_fxe_control_data) as f:
+        tids = [tid for (tid, _) in f.trains(train_range=by_id[:10003])]
+        assert tids == [10000, 10001, 10002]
+
+        tids = [tid for (tid, _) in f.trains(train_range=by_index[-2:])]
+        assert tids == [10398, 10399]
 
 def test_iterate_trains_select_keys(mock_fxe_control_data):
     sel = {
@@ -100,7 +110,13 @@ def test_iterate_fxe_run(mock_fxe_run):
 def test_iterate_select_trains(mock_fxe_run):
     run = RunDirectory(mock_fxe_run)
 
-    tids = [tid for (tid, _) in run.trains(train_range=range(10004, 10006))]
+    tids = [tid for (tid, _) in run.trains(train_range=by_id[10004:10006])]
+    assert tids == [10004, 10005]
+
+    tids = [tid for (tid, _) in run.trains(train_range=by_id[:10003])]
+    assert tids == [10000, 10001, 10002]
+
+    tids = [tid for (tid, _) in run.trains(train_range=by_index[4:6])]
     assert tids == [10004, 10005]
 
 def test_iterate_run_glob_devices(mock_fxe_run):


### PR DESCRIPTION
Following an email from Dmitry, here are some proposed additions to the `.trains()` method:

- Selecting sources and keys gains the ability to use glob syntax, as I used for making pandas dataframes. E.g. if you only want detector data, you could write:

```python
for tid, data in run.trains([('*/DET/*', 'image.data')])
```

- In combination with this, you can opt to skip any trains which don't have data for all the sources you requested:

```python
for tid, data in run.trains([('*/DET/*', 'image.data')], partial=False)
```

- You can also specify a range of train IDs:

```python
for tid, data in run.trains(train_range=range(10004, 100024))
```

The design of all this is up for discussion. Of the code Dmitry sent us, this is the bit I'm trying to make it easier to do:

```python
for trainID in trainIDs[takeTrainsBegin:takeTrainsEnd+1]:
#    print("Processing train",trainID)
    
    tid, train_data = run.train_from_id(trainID)
    NoData = False
    for dev in sorted(train_data.keys()):
#        print(dev, end='\t')
        try:
#            print(train_data[dev]['image.data'].shape)
            train_data[dev]['image.data']
        except KeyError:
            print("No image.data for trainID",trainID)
            NoData = True
            break
    if NoData:
        continue
```