### PR TITLE
Start of a framework for checking data files

### DIFF
--- a/karabo_data/validation.py
+++ b/karabo_data/validation.py
@@ -1,4 +1,6 @@
 import numpy as np
+import os
+import sys
 
 class ValidationError(Exception):
     def __init__(self, problems):
@@ -104,3 +106,27 @@ class RunValidator:
             fv = FileValidator(f)
             fv.validate()
             self.problems.extend(fv.problems)
+
+def main(argv=None):
+    from .reader import RunDirectory, H5File
+    if argv is None:
+        argv = sys.argv[1:]
+
+    path = argv[0]
+    if os.path.isdir(path):
+        print("Checking run directory:", path)
+        validator = RunValidator(RunDirectory(path))
+    else:
+        print("Checking file:", path)
+        validator = FileValidator(H5File(path))
+
+    try:
+        validator.validate()
+        print("No problems found")
+    except ValidationError as ve:
+        print("Validation failed!")
+        print(str(ve))
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/karabo_data/validation.py
+++ b/karabo_data/validation.py
@@ -9,7 +9,8 @@ class ValidationError(Exception):
         for prob in self.problems:
             lines.extend(['', prob['msg']])
             for k, v in sorted(prob.items()):
-                lines.append("  {}: {}".format(k, v))
+                if k != 'msg':
+                    lines.append("  {}: {}".format(k, v))
 
         return '\n'.join(lines)
 

--- a/karabo_data/validation.py
+++ b/karabo_data/validation.py
@@ -1,0 +1,77 @@
+import numpy as np
+
+class FileValidator:
+    def __init__(self, file):
+        self.file = file
+        self.filename = file.file.filename
+        self.problems = []
+
+    def validate(self):
+        self.problems = []
+        self.check_indices()
+        return self.problems
+
+    def check_indices(self):
+        for src in self.file.instrument_sources:
+            h5_sources = set()
+            for key in self.file._keys_for_source():
+                ds_path = 'INSTRUMENT/{}/{}'.format(src, key.replace('.', '/'))
+                h5_source = src + '/' + key.split('.', 1)[0]
+                first, count = self.file._read_index(h5_source)
+                data_dim0 = self.file.file[ds_path].shape[0]
+                if np.any((first + count) > data_dim0):
+                    max_end = (first + count).max()
+                    self.problems.append({
+                        'msg': 'Index referring to data ({}) outside dataset ({})'
+                               .format(max_end, data_dim0),
+                        'file': self.filename,
+                        'dataset': ds_path,
+                    })
+
+            for h5_source in h5_sources:
+                context = {
+                    'file': self.filename,
+                    'dataset': 'INDEX/' + h5_source,
+                }
+                first, count = self.file._read_index(h5_source)
+                self.problems.extend(check_index_contiguous(first, count, context))
+
+def check_index_contiguous(firsts, counts, context):
+    probs = []
+
+    probs.append(dict(
+        msg="Index doesn't start at 0",
+        **context
+    ))
+
+    if np.all((firsts + counts)[:-1] == firsts[1:]):
+        return probs
+
+    for ix, (first, count, first_next) in enumerate(zip(firsts, counts, firsts[1:])):
+        if (first + count) < first_next:
+            probs.append(dict(
+                msg="Gap in index at {} ({} + {} < {})".format(
+                    ix, first, count, first_next
+                ),
+                **context
+            ))
+        elif (first + count) > first_next:
+            probs.append(dict(
+                msg="Overlap in index at {} ({} + {} > {})".format(
+                    ix, first, count, first_next
+                ),
+                **context
+            ))
+
+    return probs
+
+class RunValidator:
+    def __init__(self, run):
+        self.run = run
+        self.problems = []
+
+    def check_files(self):
+        for f in self.run.files:
+            fv = FileValidator(f)
+            fv.validate()
+            self.problems.extend(fv.problems)

--- a/karabo_data/validation.py
+++ b/karabo_data/validation.py
@@ -1,5 +1,18 @@
 import numpy as np
 
+class ValidationError(Exception):
+    def __init__(self, problems):
+        self.problems = problems
+
+    def __str__(self):
+        lines = []
+        for prob in self.problems:
+            lines.extend(['', prob['msg']])
+            for k, v in sorted(prob.items()):
+                lines.append("  {}: {}".format(k, v))
+
+        return '\n'.join(lines)
+
 class FileValidator:
     def __init__(self, file):
         self.file = file
@@ -7,6 +20,11 @@ class FileValidator:
         self.problems = []
 
     def validate(self):
+        problems = self.run_checks()
+        if problems:
+            raise ValidationError(problems)
+
+    def run_checks(self):
         self.problems = []
         self.check_indices()
         return self.problems
@@ -69,6 +87,16 @@ class RunValidator:
     def __init__(self, run):
         self.run = run
         self.problems = []
+
+    def validate(self):
+        problems = self.run_checks()
+        if problems:
+            raise ValidationError(problems)
+
+    def run_checks(self):
+        self.problems = []
+        self.check_files()
+        return self.problems
 
     def check_files(self):
         for f in self.run.files:

--- a/karabo_data/validation.py
+++ b/karabo_data/validation.py
@@ -14,7 +14,7 @@ class FileValidator:
     def check_indices(self):
         for src in self.file.instrument_sources:
             h5_sources = set()
-            for key in self.file._keys_for_source():
+            for key in self.file._keys_for_source(src):
                 ds_path = 'INSTRUMENT/{}/{}'.format(src, key.replace('.', '/'))
                 h5_source = src + '/' + key.split('.', 1)[0]
                 first, count = self.file._read_index(h5_source)


### PR DESCRIPTION
See #31. I'm not totally happy with the design of this, but it's a starting point to experiment with.

It can be used at the command line like this:

```
$ python3 -m karabo_data.validation /gpfs/exfel/exp/FXE/201701/p002026/proc/r0078
Checking run directory: /gpfs/exfel/exp/FXE/201701/p002026/proc/r0078
Validation failed!

Index referring to data (9300) outside dataset (2480)
  dataset: INSTRUMENT/FXE_DET_LPD1M-1/DET/3CH0:xtdf/image/length
  file: /gpfs/exfel/exp/FXE/201701/p002026/proc/r0078/CORR-R0078-LPD03-S00003.h5

Index referring to data (9300) outside dataset (2480)
  dataset: INSTRUMENT/FXE_DET_LPD1M-1/DET/3CH0:xtdf/image/trainId
  file: /gpfs/exfel/exp/FXE/201701/p002026/proc/r0078/CORR-R0078-LPD03-S00003.h5
...
```