### PR TITLE
Don't generate timestamps when reading data

### DIFF
--- a/karabo_data/export.py
+++ b/karabo_data/export.py
@@ -14,7 +14,6 @@ from argparse import ArgumentParser
 import os.path as osp
 from queue import Queue
 from threading import Event, Thread
-from time import time
 
 import msgpack
 import numpy as np

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -19,7 +19,6 @@ import numpy as np
 import os.path as osp
 import pandas as pd
 import re
-from time import time
 import xarray as xr
 
 
@@ -297,9 +296,6 @@ class H5File:
         train_data = defaultdict(dict)
 
         train_id = self.train_ids[train_index]
-        ts = time()
-        sec, frac = str(ts).split('.')
-        frac = frac.ljust(18, '0')
 
         if only_this is not None:
             for source, key in only_this:
@@ -327,10 +323,7 @@ class H5File:
 
                 train_data[source]['metadata'] = {
                     'source': source,
-                    'timestamp': ts,
                     'timestamp.tid': train_id,
-                    'timestamp.sec': sec,
-                    'frac': frac,
                 }
             return train_id, train_data
 
@@ -364,10 +357,7 @@ class H5File:
 
             train_data[device]['metadata'] = {
                 'source': source,
-                'timestamp': ts,
                 'timestamp.tid': train_id,
-                'timestamp.sec': sec,
-                'frac': frac,
             }
 
         return train_id, train_data


### PR DESCRIPTION
From discussions a couple of weeks ago, the files don't currently store any timestamps, so we can't even give an approximate time for a given train. We hope that in the future, timestamps from the time server will be recorded in the file.

In the meantime, I think we shouldn't generate timestamps when reading the file. This makes the metadata different from that given by `karabo_bridge`: you can't assume that timestamps are present. I think it's better to have that difference than to fill in the gap with misleading values.