### PR TITLE
New exception handle in stack_detector_data

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1234,6 +1234,12 @@ def stack_detector_data(train, data, axis=-3, modules=16, only='', xcept=()):
         except IndexError:
             print('stack_detector_Data(): module {} is out or range for a'
                   'detector of {} modules'.format(index, modules))
+        except ValueError:
+            print('stack_detector_Data(): inconsistent data shape of {} in {}: '
+                  'found both {} and {}'.format(data,
+                                                device,
+                                                combined.shape[1:],
+                                                train[device][data].shape))
     return np.moveaxis(combined, 0, axis)
 
 


### PR DESCRIPTION
Found new exception due to ill data in data set 0067 used by Dmitry

An example error message:

stack_detector_Data(): inconsistent data shape of image.data in FXE_DET_LPD1M-1/DET/8CH0:xtdf: found both (60, 256, 256) and (52, 256, 256)