### PR TITLE
Return an empty array when no data was recorded

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1032,7 +1032,17 @@ class RunDirectory:
                       for f in self.files
                       if device in (f.control_sources | f.instrument_sources)]
 
-        return xr.concat(sorted(seq_arrays, key=lambda a: a.coords['trainId'][0]),
+        non_empty = [a for a in seq_arrays if (a.size > 0)]
+        if not non_empty:
+            if seq_arrays:
+                # All per-file arrays are empty, so just return the first one.
+                return seq_arrays[0]
+
+            raise Exception(("Unable to get data for source {!r}, key {!r}. "
+                             "Please report an issue so we can investigate")
+                            .format(device, key))
+
+        return xr.concat(sorted(non_empty, key=lambda a: a.coords['trainId'][0]),
                          dim='trainId')
 
     def _assemble_sequences(self):

--- a/karabo_data/tests/make_examples.py
+++ b/karabo_data/tests/make_examples.py
@@ -225,11 +225,13 @@ def make_fxe_run(dir_path):
         XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
         XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA'),
+        GECCamera('FXE_XAD_GEC/CAM/CAMERA_NODATA', nsamples=0),
     ], ntrains=400, chunksize=200)
     write_file(osp.join(dir_path, 'RAW-R0450-DA01-S00001.h5'), [
         XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
         XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA'),
+        GECCamera('FXE_XAD_GEC/CAM/CAMERA_NODATA', nsamples=0),
     ], ntrains=80, firsttrain=10400, chunksize=200)
 
 if __name__ == '__main__':

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -211,6 +211,14 @@ def test_run_get_array(mock_fxe_run):
     assert arr.shape == (480, 1000)
     assert arr.coords['trainId'][0] == 10000
 
+def test_run_get_array_empty(mock_fxe_run):
+    run = RunDirectory(mock_fxe_run)
+    arr = run.get_array('FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput', 'data.image.pixels')
+
+    assert isinstance(arr, DataArray)
+    assert arr.dims[0] == 'trainId'
+    assert arr.shape == (0, 255, 1024)
+
 def test_run_get_array_error(mock_fxe_run):
     run = RunDirectory(mock_fxe_run)
 


### PR DESCRIPTION
Closes #60

I also considered an option that raised a new error class. But I think it makes sense to have an empty array represent a valid name which has no data. The extra dimensions of the array (e.g. camera pixel dimensions) may still have meaning.

This also makes it consistent with retrieving an array from a single file, which already returns an empty array in this case.