### PR TITLE
Writing selected data back to HDF5 file

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -899,6 +899,18 @@ class DataCollection:
         print('\tControls')
         [print('\t-', d) for d in sorted(ctrl)] or print('\t-')
 
+    def write(self, filename):
+        """Write the selected data to a new HDF5 file
+
+        You can choose a subset of the data using methods
+        like :meth:`select` and :meth:`select_trains`,
+        then use this write it to a new, smaller file.
+
+        The target filename will be overwritten if it already exists.
+        """
+        from .writer import FileWriter
+        FileWriter(filename, self).write()
+
 class TrainIterator:
     """Iterate over trains in a collection of data
 

--- a/karabo_data/tests/test_writer.py
+++ b/karabo_data/tests/test_writer.py
@@ -1,0 +1,25 @@
+import os.path as osp
+from tempfile import TemporaryDirectory
+from testpath import assert_isfile
+
+from karabo_data import RunDirectory, H5File
+
+def test_write_selected(mock_fxe_run):
+    with TemporaryDirectory() as td:
+        new_file = osp.join(td, 'test.h5')
+
+        with RunDirectory(mock_fxe_run) as run:
+            run.select('SPB_XTD9_XGM/*').write(new_file)
+
+        assert_isfile(new_file)
+
+        with H5File(new_file) as f:
+            assert f.control_sources == {'SPB_XTD9_XGM/DOOCS/MAIN'}
+            assert f.instrument_sources == {'SPB_XTD9_XGM/DOOCS/MAIN:output'}
+
+            s = f.get_series('SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value')
+            # This should have concatenated the two sequence files (400 + 80)
+            assert len(s) == 480
+
+            a = f.get_array('SPB_XTD9_XGM/DOOCS/MAIN:output', 'data.intensityTD')
+            assert a.shape == (480, 1000)

--- a/karabo_data/writer.py
+++ b/karabo_data/writer.py
@@ -70,6 +70,10 @@ class FileWriter:
                                               dtype=vlen_bytes, maxshape=(None,))
         devices_ds[:] = [ds.split('/', 1)[1] for ds in data_sources]
 
+    def set_writer(self):
+        from . import __version__
+        self.file.attrs['writer'] = 'karabo_data {}'.format(__version__)
+
     def write(self):
         d = self.data
         self.file.create_dataset('INDEX/trainId', data=d.train_ids, dtype='u8')
@@ -84,3 +88,4 @@ class FileWriter:
 
         self.write_indexes()
         self.write_metadata()
+        self.set_writer()

--- a/karabo_data/writer.py
+++ b/karabo_data/writer.py
@@ -1,0 +1,81 @@
+import h5py
+import numpy as np
+
+class FileWriter:
+    """Write data in European XFEL HDF5 format
+
+    This is intended to allow copying a subset of data into a smaller,
+    more portable file.
+    """
+    def __init__(self, path, data):
+        self.file = h5py.File(path, 'w')
+        self.data = data
+        self.indexes = {} # {path: (first, count)}
+        self.data_sources = set()
+
+    def add_control_dataset(self, source, key):
+        a = self.data.get_array(source, key)
+        path = 'CONTROL/{}/{}'.format(source, key.replace('.', '/'))
+        self.file[path] = a.values
+
+        if source not in self.indexes:
+            n = a.shape[0]
+            self.indexes[source] = \
+                (np.arange(n, dtype='u8'), np.ones(n, dtype='u8'))
+            self.data_sources.add('CONTROL/' + source)
+
+    def add_instrument_dataset(self, source, key):
+        a = self.data.get_array(source, key)
+        path = 'INSTRUMENT/{}/{}'.format(source, key.replace('.', '/'))
+        self.file[path] = a.values
+
+        index_path = source + '/' + key.partition('.')[0]
+        if index_path not in self.indexes:
+            # Convert an array of train IDs to first/count for each train
+            data_tids = a.coords['trainId']
+            first, count = [], []
+            for tid in self.data.train_ids:
+                matches = (data_tids == tid)
+                first.append(matches.nonzero()[0][0])
+                count.append(matches.sum())
+
+            self.indexes[index_path] = \
+                (np.array(first, dtype='u8'), np.array(count, dtype='u8'))
+            self.data_sources.add('INSTRUMENT/' + index_path)
+
+    def write_indexes(self):
+        for groupname, (first, count) in self.indexes.items():
+            self.file['INDEX/{}/first'.format(groupname)] = first
+            self.file['INDEX/{}/count'.format(groupname)] = count
+
+    def write_metadata(self):
+        vlen_bytes = h5py.special_dtype(vlen=bytes)
+        data_sources = sorted(self.data_sources)
+        N = len(data_sources)
+
+        sources_ds = self.file.create_dataset('METADATA/dataSourceId', (N,),
+                                              dtype=vlen_bytes, maxshape=(None,))
+        sources_ds[:] = data_sources
+
+        root_ds = self.file.create_dataset('METADATA/root', (N,),
+                                           dtype=vlen_bytes, maxshape=(None,))
+        root_ds[:] = [ds.split('/', 1)[0] for ds in data_sources]
+
+        devices_ds = self.file.create_dataset('METADATA/deviceId', (N,),
+                                              dtype=vlen_bytes, maxshape=(None,))
+        devices_ds[:] = [ds.split('/', 1)[1] for ds in data_sources]
+
+    def write(self):
+        d = self.data
+        self.file.create_dataset('INDEX/trainId', data=d.train_ids, dtype='u8')
+
+        for source in d.control_sources:
+            for key in d._keys_for_source(source):
+                self.add_control_dataset(source, key)
+
+        for source in d.instrument_sources:
+            for key in d._keys_for_source(source):
+                self.add_instrument_dataset(source, key)
+
+        self.write_indexes()
+        self.write_metadata()


### PR DESCRIPTION
This adds an interface to write selected data back to an HDF5 file in the same format (so it can be loaded with karabo_data again). Use it like this:

```python
from karabo_data import RunDirectory
run = RunDirectory('/gpfs/exfel/exp/SA1/201830/p900025/raw/r0150')
run.select('SA1_XTD2_XGM/*').write('/gpfs/exfel/exp/SA1/201830/p900025/scratch/test_xtd2_r150.h5')
```

This writes a single file - it doesn't try to create sequence files or split up different sources into different files.

The data is copied into the new file, it doesn't use references to the source files like the virtual dataset work. That means you can take the file outside of Maxwell and load it. But if you try to use this to make a file with all detector data, it will be a very big file. The virtual datasets are a better way to provide a combined view of detector data.
