### PR TITLE
Skip bad files

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -272,8 +272,8 @@ class DataCollection:
             try:
                 fa = FileAccess(h5py.File(path, 'r'))
             except Exception as e:
-                print("Skipping file", path, ": couldn't open", file=sys.stderr)
-                print("  ({})".format(e), file=sys.stderr)
+                print("Skipping file", path, file=sys.stderr)
+                print("  (error was: {})".format(e), file=sys.stderr)
             else:
                 files.append(fa)
 

--- a/karabo_data/tests/conftest.py
+++ b/karabo_data/tests/conftest.py
@@ -1,3 +1,4 @@
+import h5py
 import os.path as osp
 import pytest
 from tempfile import TemporaryDirectory
@@ -45,3 +46,12 @@ def mock_fxe_run():
     with TemporaryDirectory() as td:
         make_examples.make_fxe_run(td)
         yield td
+
+@pytest.fixture(scope='module')
+def empty_h5_file():
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'empty.h5')
+        with h5py.File(path, 'w'):
+            pass
+
+        yield path

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -5,7 +5,7 @@ from xarray import DataArray
 
 from karabo_data import (
     H5File, RunDirectory, stack_data, stack_detector_data, by_index, by_id,
-    SourceNameError, PropertyNameError,
+    SourceNameError, PropertyNameError, DataCollection,
 )
 
 
@@ -304,6 +304,12 @@ def test_union(mock_fxe_run):
     sel2 = run.select_trains(by_index[:10])
     joined = sel1.union(sel2)
     assert joined.train_ids == list(range(10000, 10010)) + list(range(10200, 10220))
+
+def test_read_skip_invalid(mock_lpd_data, empty_h5_file, capsys):
+    d = DataCollection.from_paths([mock_lpd_data, empty_h5_file])
+    assert d.instrument_sources == {'FXE_DET_LPD1M-1/DET/0CH0:xtdf'}
+    out, err = capsys.readouterr()
+    assert "Skipping file" in err
 
 def test_stack_data(mock_fxe_run):
     test_run = RunDirectory(mock_fxe_run)


### PR DESCRIPTION
Fixes #75 .

This will print a warning on stderr if it encounters a file it can't open, like this:

```
Skipping file /gpfs/exfel/exp/FXE/201830/p900023/proc/r0300/CORR-R0300-LPD07-S00000.h5
  (error was: 'Unable to open object (component not found)')
```

It will continue if it opened at least one of the files in the directory. If it couldn't open any, it still throws an error.