### PR TITLE
Value error raised in stack detector function fixed

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1134,17 +1134,21 @@ def stack_detector_data(train, data, axis=-3, modules=16, only='', xcept=()):
         shapes.add(array.shape)
         modno_arrays[modno] = array
 
+    required_shape = (sorted(shapes, key=lambda x: x[0], reverse = True))[0]
     if len(dtypes) > 1:
         raise ValueError("Arrays have mismatched dtypes: {}".format(dtypes))
     if len(shapes) > 1:
-        raise ValueError("Arrays have mismatched shapes: {}".format(shapes))
+        for modno, array in modno_arrays.items():
+            if array.shape != required_shape:
+                modno_arrays[modno] = np.full(required_shape, np.nan, dtype = array.dtype)
+        # raise ValueError("Arrays have mismatched shapes: {}".format(shapes))
     if max(modno_arrays) >= modules:
         raise IndexError("Module {} is out of range for a detector with {} modules"
                          .format(max(modno_arrays), modules))
 
     dtype = dtypes.pop()
-    shape = shapes.pop()
-
+    # shape = shapes.pop()
+    shape = required_shape
     combined = np.full((modules, ) + shape, np.nan, dtype=dtype)
     for modno, array in modno_arrays.items():
         combined[modno] = array

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1134,14 +1134,19 @@ def stack_detector_data(train, data, axis=-3, modules=16, only='', xcept=()):
         shapes.add(array.shape)
         modno_arrays[modno] = array
 
-    required_shape = (sorted(shapes, key=lambda x: x[0], reverse = True))[0]
+    required_shape = (sorted(shapes, key=lambda x: x[0] , reverse = True))[0]
     if len(dtypes) > 1:
         raise ValueError("Arrays have mismatched dtypes: {}".format(dtypes))
     if len(shapes) > 1:
-        for modno, array in modno_arrays.items():
-            if array.shape != required_shape:
-                modno_arrays[modno] = np.full(required_shape, np.nan, dtype = array.dtype)
-        # raise ValueError("Arrays have mismatched shapes: {}".format(shapes))
+        size_set =  { x[1:] for x in shapes }
+        pulse_set = { x[0]  for x in shapes }
+        if len(size_set) > 1 or len(pulse_set) > 2 or sorted(pulse_set)[0] != 0:
+            raise ValueError("Arrays have mismatched shapes: {}".format(shapes))
+        else:
+            for modno, array in modno_arrays.items():
+                if array.shape != required_shape:
+                    modno_arrays[modno] = np.full(required_shape, np.nan, dtype = array.dtype)
+        
     if max(modno_arrays) >= modules:
         raise IndexError("Module {} is out of range for a detector with {} modules"
                          .format(max(modno_arrays), modules))


### PR DESCRIPTION
Assuming that 'image.data' is of form (num_pulses, px,py). It was happening that some module sends image with num_pulses = 0 and   remaining modules num_pulses=60, then Value error was raised in Stack_detector_data function. I now fill those modules with num_pulses=0 to np.nan and they are now of shape of modules which do have full data for eg. (60,px,py).  