### PR TITLE
Allow selecting a list of trains

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -789,6 +789,9 @@ class DataCollection:
         elif isinstance(tr, by_id) and isinstance(tr.value, (list, np.ndarray)):
             # Select a list of trains by train ID
             new_train_ids = sorted(set(self.train_ids).intersection(tr.value))
+            if not new_train_ids:
+                raise ValueError("Given train IDs not found among {} trains in "
+                                 "collection".format(len(self.train_ids)))
         elif isinstance(tr, by_index) and isinstance(tr.value, (list, np.ndarray)):
             # Select a list of trains by index in this collection
             new_train_ids = sorted([self.train_ids[i] for i in tr.value])

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -316,6 +316,9 @@ def test_select_trains(mock_fxe_run):
     sel = run.select_trains(by_id[[9950, 10000, 10101, 10500]])
     assert sel.train_ids == [10000, 10101]
 
+    with pytest.raises(ValueError):
+        run.select_trains(by_id[[9900, 10600]])
+
     # Select a list of indexes
     sel = run.select_trains(by_index[[5, 25]])
     assert sel.train_ids == [10005, 10025]

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -312,6 +312,17 @@ def test_select_trains(mock_fxe_run):
     with pytest.raises(ValueError):
         run.select_trains(by_id[12000:12500])  # After data
 
+    # Select a list of train IDs
+    sel = run.select_trains(by_id[[9950, 10000, 10101, 10500]])
+    assert sel.train_ids == [10000, 10101]
+
+    # Select a list of indexes
+    sel = run.select_trains(by_index[[5, 25]])
+    assert sel.train_ids == [10005, 10025]
+
+    with pytest.raises(IndexError):
+        run.select_trains(by_index[[480]])
+
 def test_union(mock_fxe_run):
     run = RunDirectory(mock_fxe_run)
 


### PR DESCRIPTION
From discussion with @CFGrote on issue #85.

Open questions about out-of-range behaviour:

- Selecting a list of train IDs will currently always succeed, ignoring any IDs that aren't present in the source collection. We could strictly check that they are all in the source collection, or have a weaker check that at least one train matched. The latter is more like what we do for slicing by train ID: we throw a ValueError if the slice range doesn't overlap with the train IDs in the source collection.
- Selecting a list of indexes will fail if any of them are out of range. We could relax that.