### PR TITLE
Apply stacked images to position all modules

### DIFF
--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -347,8 +347,8 @@ class AGIPD_1M_SnappedGeometry:
           (y, x) pixel location of the detector centre in this geometry.
         """
         assert data.shape[-3:] == (16, 512, 128)
-        size_yx, centre = self._plotting_dimensions(data.shape)
-        out = np.full(size_yx, np.nan, dtype=data.dtype)
+        size_yx, centre = self._plotting_dimensions()
+        out = np.full(data.shape[:-3] + size_yx, np.nan, dtype=data.dtype)
         for i, module in enumerate(self.modules):
             mod_data = data[..., i, :, :]
             tiles_data = np.split(mod_data, 8, axis=-2)
@@ -361,7 +361,7 @@ class AGIPD_1M_SnappedGeometry:
 
         return out, centre
 
-    def _plotting_dimensions(self, shape=(16, 512, 128)):
+    def _plotting_dimensions(self):
         """Calculate appropriate dimensions for plotting assembled data
 
         Returns (size_y, size_x), (centre_y, centre_x)
@@ -377,9 +377,9 @@ class AGIPD_1M_SnappedGeometry:
         min_yx = corners.min(axis=0) - 20
         max_yx = corners.max(axis=0) + 20
 
-        size = shape[:-3] + tuple(max_yx - min_yx)
+        size = max_yx - min_yx
         centre = -min_yx
-        return size, centre
+        return tuple(size), centre
 
     def plot_data(self, modules_data):
         """Plot data from the detector using this geometry.


### PR DESCRIPTION
We noticed that the ```position_all_modules methods``` can "only" handle one pulse at a time. When testing the application of AGIPD geometry with karaboFai during last weeks experiment commissioning we figured that we should be able to deal with data that comes in multiple pulses. 

Hence I gave it a go and changed the ```positions_all_modules methods``` in both classes. While the method for the 'snapped' geometry was straight forward ```positions_all_modules``` of the ```AGIPD_1MGeometry``` was somewhat more tricky. 

First I tried to construct a 3D rotation matrix for a rotation around a homogeneous axis. But that did not work, it might well be that I did something wrong here, I am also not sure if that is what we should do in this case (3D rotation). This [book](https://books.google.de/books?id=J9b_CH-NrycC&lpg=PP1&pg=PA67#v=twopage&q&f=false) shows an example where they loop over the 3rd (color) axis (page 67). So I assume we also have to loop, which makes the routine even slower. [Apparently openCV is able to do an affine transformation on a  3D image](https://stackoverflow.com/questions/44674129/how-can-i-use-scipys-affine-transform-to-do-an-arbitrary-affine-transformation). But adding openCV as a requirement for only this feature is sure overkill. 

@takluyver @tmichela @zhujun98 @ebadkamil any thoughts?