### PR TITLE
Make run sources frozen sets

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -163,6 +163,9 @@ class FileAccess:
             else:
                 raise ValueError("Unknown data category %r" % category)
 
+        self.control_sources = frozenset(self.control_sources)
+        self.instrument_sources = frozenset(self.instrument_sources)
+
         # {(file, source, group): (firsts, counts)}
         self._index_cache = {}
         # {source: set(keys)}

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -264,6 +264,9 @@ class DataCollection:
         # Throw an error if we have conflicting data for the same source
         self._check_source_conflicts()
 
+        self.control_sources = frozenset(self.control_sources)
+        self.instrument_sources = frozenset(self.instrument_sources)
+
         if train_ids is None:
             train_ids = sorted(set().union(*(f.train_ids for f in files)))
         self.train_ids = train_ids

--- a/karabo_data/tests/test_reader.py
+++ b/karabo_data/tests/test_reader.py
@@ -238,6 +238,17 @@ def test_filter_device():
         assert len(data['SA1_XTD2_XGM/XGM/DOOCS']) == 2
 
 
+@xgm_run
+def test_run_all_sources():
+    test_run = RunDirectory(RUNPATH)
+    before = len(test_run.all_sources)
+
+    with pytest.raises(AttributeError):
+        test_run.all_sources.pop()
+
+    assert len(test_run.all_sources) == before
+
+
 @agipd_run
 def test_run_info(capsys):
     test_run = RunDirectory(RUNPATH)

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -405,3 +405,12 @@ def test_stack_detector_data_extra_mods(mock_fxe_run):
     with pytest.raises(IndexError) as excinfo:
         comb = stack_detector_data(data, 'image.data')
     assert "16" in str(excinfo.value)
+
+def test_run_immutable_sources(mock_fxe_run):
+    test_run = RunDirectory(mock_fxe_run)
+    before = len(test_run.all_sources)
+
+    with pytest.raises(AttributeError):
+        test_run.all_sources.pop()
+
+    assert len(test_run.all_sources) == before


### PR DESCRIPTION
Previously, a user could mess up known sources by popping from the sources sets:
```python
In [1]: from karabo_data import RunDirectory
In [2]: run = RunDirectory(".")

In [3]: run.all_sources
Out[3]: {'SQS_DIGITIZER_UTC1/ADC/1', 'SQS_DIGITIZER_UTC1/ADC/1:network'}

In [4]: run.instrument_sources.pop()
Out[4]: 'SQS_DIGITIZER_UTC1/ADC/1:network'

In [5]: run.all_sources
Out[5]: {'SQS_DIGITIZER_UTC1/ADC/1'}
```
All four `{control,instrument,detector,all}_sources` were affected

This resolves this issues by making these frozensets.