### PR TITLE
Distortion

### DIFF
--- a/karabo_data/geometry.py
+++ b/karabo_data/geometry.py
@@ -254,7 +254,8 @@ class LPDGeometry(GeometryFragment):
 
                 # idx, idy : Bottom left index of tiles in (1024,1024) array
                 idx, idy = np.add(_quad['Q%d' % Q],
-                              np.add(_modules['M%d' % M], _tiles['T%01d' % T]))
+                                  np.add(_modules['M%d' % M],
+                                  _tiles['T%01d' % T]))
 
                 xt, yt = (position // self.pixel_size) + centre
                 xt, yt = int(xt), int(yt)
@@ -299,43 +300,37 @@ class LPDGeometry(GeometryFragment):
 
         # Bottom left position index of Quadrants Size (1024,1024)
         # See locations from inspect()
-        _quad['Q1'] = (512,0)
-        _quad['Q2'] = (512,512)
-        _quad['Q3'] = (0,512)
-        _quad['Q4'] = (0,0)
+        _quad['Q1'] = (512, 0)
+        _quad['Q2'] = (512, 512)
+        _quad['Q3'] = (0, 512)
+        _quad['Q4'] = (0, 0)
 
         # Bottom left position index of modules with respect to Quadrant
-        _modules['M1'] = (256,0)
-        _modules['M2'] = (256,256)
-        _modules['M3'] = (0,256)
-        _modules['M4'] = (0,0)
+        _modules['M1'] = (256, 0)
+        _modules['M2'] = (256, 256)
+        _modules['M3'] = (0, 256)
+        _modules['M4'] = (0, 0)
 
         # Bottom left position index of tiles with respect to Modules
-        offset_r = (128,0)
-        offset_l = (0,256)
+        offset_r = (128, 0)
+        offset_l = (0, 256)
         for tileno in range(1,17):
             if tileno <= 8:
-                _tiles['T%d'%tileno] = tuple(offset_r)
-                offset_r = np.add(offset_r,(0,32))
+                _tiles['T%d' % tileno] = tuple(offset_r)
+                offset_r = np.add(offset_r, (0, 32))
             else:
-                offset_l = np.subtract(offset_l,(0,32))
-                _tiles['T%d'%tileno] = tuple(offset_l)
+                offset_l = np.subtract(offset_l, (0, 32))
+                _tiles['T%d' % tileno] = tuple(offset_l)
 
         return _quad, _modules, _tiles
 
-if __name__ == '__main__':
 
-    import matplotlib.pyplot as plt
+if __name__ == '__main__':
 
     quadpos = [(-11.4, -299), (11.5, -8), (-254.5, 16), (-278.5, -275)]  # MAR 18
     with h5py.File(sys.argv[1], 'r') as f:
         geom = LPDGeometry.from_h5_file_and_quad_positions(f, quadpos, unit=1e-3)
 
-    distortion = geom.generateDistortion()
-
-    plt.figure()
-    plt.scatter(distortion[:,:,1,2],distortion[:,:,1,1], s=0.001)
-    plt.show()
     print(geom)
     print('Q2/M1/T07:', geom.find_offset(('Q2', 'M1', 'T07')))
 

--- a/karabo_data/geometry.py
+++ b/karabo_data/geometry.py
@@ -258,6 +258,7 @@ class LPDGeometry(GeometryFragment):
                 idx, idy = _tiles['T%01d' % T]
 
                 xt, yt = (position // self.pixel_size) + centre
+
                 xt, yt = int(xt), int(yt)
                 # y_position contains y_indices of pixels for a tile
                 # x_position contains x_indices of pixels for a tile
@@ -281,15 +282,15 @@ class LPDGeometry(GeometryFragment):
         return distortion
 
     def _create_qmt_dict(self):
-        """Returns dictionary for bottom left indices of tiles
+        """Returns dictionary for top left indices of tiles
 
-        _tiles: bottom left index of 16 tiles with respect to the module
+        _tiles: top left index of 16 tiles with respect to the module
                 tiles are arranged in clockwise order starting from top
                 right.
         """
         _tiles = dict()
 
-        # Bottom left position index of tiles with respect to Modules
+        # top left position index of tiles with respect to Modules
         offset_r = (128, 0)
         offset_l = (0, 256)
         for tileno in range(1,17):

--- a/karabo_data/geometry.py
+++ b/karabo_data/geometry.py
@@ -260,32 +260,23 @@ class LPDGeometry(GeometryFragment):
                 xt, yt = (position // self.pixel_size) + centre
                 xt, yt = int(xt), int(yt)
                 # y_position contains y_indices of pixels for a tile
-                y_position = np.array(
-                    [yt+j for j, _ in product(range(32), range(128))]).\
-                    reshape(32, 128)
                 # x_position contains x_indices of pixels for a tile
-                x_position = np.array(
-                    [xt+i for _, i in product(range(32), range(128))]).\
-                    reshape(32, 128)
+                x_position, y_position = np.meshgrid(range(128), range(32))
+                x_position = x_position + xt
+                y_position = y_position + yt
+
                 # From the pixel location evaluate X and Y corordinates
                 # of its 4 corners in real space.
                 # Z position is set to 0 (Flat detector)
-                distortion[ch+idy:ch+idy+32, idx:idx+128, 0, 1] = (
-                    self.pixel_size*y_position[:, :] - 0.5*self.pixel_size)
-                distortion[ch+idy:ch+idy+32, idx:idx+128, 1, 1] = (
-                    self.pixel_size*y_position[:, :] + 0.5*self.pixel_size)
-                distortion[ch+idy:ch+idy+32, idx:idx+128, 2, 1] = (
-                    self.pixel_size*y_position[:, :] + 0.5*self.pixel_size)
-                distortion[ch+idy:ch+idy+32, idx:idx+128, 3, 1] = (
-                    self.pixel_size*y_position[:, :] - 0.5*self.pixel_size)
-                distortion[ch+idy:ch+idy+32, idx:idx+128, 0, 2] = (
-                    self.pixel_size*x_position[:, :] - 0.5*self.pixel_size)
-                distortion[ch+idy:ch+idy+32, idx:idx+128, 1, 2] = (
-                    self.pixel_size*x_position[:, :] - 0.5*self.pixel_size)
-                distortion[ch+idy:ch+idy+32, idx:idx+128, 2, 2] = (
-                    self.pixel_size*x_position[:, :] + 0.5*self.pixel_size)
-                distortion[idy:idy+32, idx:idx+128, 3, 2] = (
-                    self.pixel_size*x_position[:, :] + 0.5*self.pixel_size)
+                corner_y_offsets = np.array([-.5, .5, .5, -.5]) * self.pixel_size
+                corner_x_offsets = np.array([-.5, -.5, .5, .5]) * self.pixel_size
+
+                distortion[ch+idy:ch+idy+32, idx:idx+128, :, 1] = (
+                    self.pixel_size*y_position[:, :, np.newaxis] +
+                    corner_y_offsets)
+                distortion[ch+idy:ch+idy+32, idx:idx+128, :, 2] = (
+                    self.pixel_size*x_position[:, :, np.newaxis] +
+                    corner_x_offsets)
 
         return distortion
 

--- a/karabo_data/geometry.py
+++ b/karabo_data/geometry.py
@@ -253,7 +253,7 @@ class LPDGeometry(GeometryFragment):
                 position = self.find_offset(('Q%d' % Q,
                                              'M%d' % M, 'T%02d' % T))
 
-                # idx, idy : Bottom left index of tiles in (256,256)
+                # idx, idy : top left index of tiles in (256,256)
                 #            module array
                 idx, idy = _tiles['T%01d' % T]
 
@@ -293,7 +293,8 @@ class LPDGeometry(GeometryFragment):
         """Returns dictionary for bottom left indices of tiles
 
         _tiles: bottom left index of 16 tiles with respect to the module
-                tiles are arranged in anti-clockwise fashion.
+                tiles are arranged in clockwise order starting from top
+                right.
         """
         _tiles = dict()
 

--- a/karabo_data/geometry.py
+++ b/karabo_data/geometry.py
@@ -195,8 +195,8 @@ class LPDGeometry(GeometryFragment):
 
         Returns a matplotlib Figure object.
         """
-        from matplotlib.backends.backend_agg import FigureCanvasAgg
-        from matplotlib.figure import Figure
+        # from matplotlib.backends.backend_agg import FigureCanvasAgg
+        # from matplotlib.figure import Figure
 
         fig = Figure((10, 10))
         FigureCanvasAgg(fig)
@@ -231,11 +231,111 @@ class LPDGeometry(GeometryFragment):
         ax.set_title('LPD detector geometry')
         return fig
 
+    def generateDistortion(self):
+        """ Return distortion matrix for LPD detector
+
+        Returns
+        -------
+        out: ndarray
+            Dimension (Ny=1024, Nx=1024, 4, 3)
+            type: float32
+            4 is the number of corners of a pixel
+            last dimension is for Z, Y, X location of each corner
+        """
+        _quad, _modules, _tiles = self._create_qmt_dict()
+        _, centre = self._plotting_dimensions()
+        distortion = np.zeros((1024, 1024, 4, 3), dtype=np.float32)
+
+        for (Q, M) in product(range(1, 5), range(1, 5)):
+
+            for T in range(1, 17):
+                position = self.find_offset(('Q%d' % Q,
+                                             'M%d' % M, 'T%02d' % T))
+
+                # idx, idy : Bottom left index of tiles in (1024,1024) array
+                idx, idy = np.add(_quad['Q%d' % Q],
+                              np.add(_modules['M%d' % M], _tiles['T%01d' % T]))
+
+                xt, yt = (position // self.pixel_size) + centre
+                xt, yt = int(xt), int(yt)
+                # y_position contains y_indices of pixels for a tile
+                y_position = np.array(
+                    [yt+j for j, _ in product(range(32), range(128))]).\
+                    reshape(32, 128)
+                # x_position contains x_indices of pixels for a tile
+                x_position = np.array(
+                    [xt+i for _, i in product(range(32), range(128))]).\
+                    reshape(32, 128)
+                # From the pixel location evaluate X and Y corordinates
+                # of its 4 corners in real space.
+                # Z position is set to 0 (Flat detector)
+                distortion[idy:idy+32, idx:idx+128, 0, 1] = (
+                    self.pixel_size*y_position[:, :] - 0.5*self.pixel_size)
+                distortion[idy:idy+32, idx:idx+128, 1, 1] = (
+                    self.pixel_size*y_position[:, :] + 0.5*self.pixel_size)
+                distortion[idy:idy+32, idx:idx+128, 2, 1] = (
+                    self.pixel_size*y_position[:, :] + 0.5*self.pixel_size)
+                distortion[idy:idy+32, idx:idx+128, 3, 1] = (
+                    self.pixel_size*y_position[:, :] - 0.5*self.pixel_size)
+                distortion[idy:idy+32, idx:idx+128, 0, 2] = (
+                    self.pixel_size*x_position[:, :] - 0.5*self.pixel_size)
+                distortion[idy:idy+32, idx:idx+128, 1, 2] = (
+                    self.pixel_size*x_position[:, :] - 0.5*self.pixel_size)
+                distortion[idy:idy+32, idx:idx+128, 2, 2] = (
+                    self.pixel_size*x_position[:, :] + 0.5*self.pixel_size)
+                distortion[idy:idy+32, idx:idx+128, 3, 2] = (
+                    self.pixel_size*x_position[:, :] + 0.5*self.pixel_size)
+
+        return distortion
+
+    def _create_qmt_dict(self):
+        """Returns dictionaries for bottom left indices
+
+        _quad : bottom left index of all 4 quadrants in 1024,1024 canvas
+        _modules: botton left index of 4 modules with respect to quadrant
+        _tiles: bottom left index of 16 tiles with respect to the module
+        """
+        _quad, _modules, _tiles = dict(), dict(), dict()
+
+        # Bottom left position index of Quadrants Size (1024,1024)
+        # See locations from inspect()
+        _quad['Q1'] = (512,0)
+        _quad['Q2'] = (512,512)
+        _quad['Q3'] = (0,512)
+        _quad['Q4'] = (0,0)
+
+        # Bottom left position index of modules with respect to Quadrant
+        _modules['M1'] = (256,0)
+        _modules['M2'] = (256,256)
+        _modules['M3'] = (0,256)
+        _modules['M4'] = (0,0)
+
+        # Bottom left position index of tiles with respect to Modules
+        offset_r = (128,0)
+        offset_l = (0,256)
+        for tileno in range(1,17):
+            if tileno <= 8:
+                _tiles['T%d'%tileno] = tuple(offset_r)
+                offset_r = np.add(offset_r,(0,32))
+            else:
+                offset_l = np.subtract(offset_l,(0,32))
+                _tiles['T%d'%tileno] = tuple(offset_l)
+
+        return _quad, _modules, _tiles
 
 if __name__ == '__main__':
+
+    import matplotlib.pyplot as plt
+
     quadpos = [(-11.4, -299), (11.5, -8), (-254.5, 16), (-278.5, -275)]  # MAR 18
     with h5py.File(sys.argv[1], 'r') as f:
         geom = LPDGeometry.from_h5_file_and_quad_positions(f, quadpos, unit=1e-3)
 
+    distortion = geom.generateDistortion()
+
+    plt.figure()
+    plt.scatter(distortion[:,:,1,2],distortion[:,:,1,1], s=0.001)
+    plt.show()
     print(geom)
     print('Q2/M1/T07:', geom.find_offset(('Q2', 'M1', 'T07')))
+

--- a/karabo_data/geometry.py
+++ b/karabo_data/geometry.py
@@ -232,7 +232,7 @@ class LPDGeometry(GeometryFragment):
         return fig
 
     def to_distortion_array(self):
-        """ Return distortion matrix for LPD detector
+        """Return distortion matrix for LPD detector, suitable for pyFAI
 
         Returns
         -------
@@ -242,7 +242,7 @@ class LPDGeometry(GeometryFragment):
             4 is the number of corners of a pixel
             last dimension is for Z, Y, X location of each corner
         """
-        _tiles = self._create_qmt_dict()
+        _tiles = self._tile_offsets()
         _, centre = self._plotting_dimensions()
         distortion = np.zeros((4096, 256, 4, 3), dtype=np.float32)
 
@@ -281,7 +281,7 @@ class LPDGeometry(GeometryFragment):
 
         return distortion
 
-    def _create_qmt_dict(self):
+    def _tile_offsets(self):
         """Returns dictionary for top left indices of tiles
 
         _tiles: top left index of 16 tiles with respect to the module

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -447,9 +447,9 @@ class AGIPD_1MGeometry:
             module_offset = m * 512
 
             for t, tile in enumerate(mod, start=0):
-                corner_x, corner_y, corner_z = tile.corner_pos
-                ss_unit_x, ss_unit_y, ss_unit_z = tile.ss_vec
-                fs_unit_x, fs_unit_y, fs_unit_z = tile.fs_vec
+                corner_x, corner_y, corner_z = tile.corner_pos * self.pixel_size
+                ss_unit_x, ss_unit_y, ss_unit_z = tile.ss_vec * self.pixel_size
+                fs_unit_x, fs_unit_y, fs_unit_z = tile.fs_vec * self.pixel_size
 
                 # Calculate coordinates of each pixel centre
                 # 2D arrays, shape: (64, 128)

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -496,6 +496,10 @@ class AGIPD_1MGeometry:
                 distortion[tile_slice, :, :, 1] = corners_y
                 distortion[tile_slice, :, :, 2] = corners_x
 
+        # Shift the x & y origin from the centre to the corner
+        min_yx = distortion[..., 1:].min(axis=(0, 1, 2))
+        distortion[..., 1:] -= min_yx
+
         return distortion
 
 

--- a/karabo_data/tests/test_agipd_geometry.py
+++ b/karabo_data/tests/test_agipd_geometry.py
@@ -70,3 +70,15 @@ def test_compare():
     # Smoketest
     fig = geom1.compare(geom2)
     assert isinstance(fig, Figure)
+
+def test_to_distortion_array():
+    geom = AGIPD_1MGeometry.from_quad_positions(quad_pos=[
+        (-525, 625),
+        (-550, -10),
+        (520, -160),
+        (542.5, 475),
+    ])
+    # Smoketest
+    distortion = geom.to_distortion_array()
+    assert isinstance(distortion, np.ndarray)
+    assert distortion.shape == (8192, 128, 4, 3)

--- a/karabo_data/tests/test_agipd_geometry.py
+++ b/karabo_data/tests/test_agipd_geometry.py
@@ -82,3 +82,7 @@ def test_to_distortion_array():
     distortion = geom.to_distortion_array()
     assert isinstance(distortion, np.ndarray)
     assert distortion.shape == (8192, 128, 4, 3)
+
+    # Coordinates in m; max x & y should be ~ 12 cm from centre
+    assert .08 < distortion[..., 1].max() < .15
+    assert .08 < distortion[..., 2].max() < .15

--- a/karabo_data/tests/test_agipd_geometry.py
+++ b/karabo_data/tests/test_agipd_geometry.py
@@ -83,6 +83,8 @@ def test_to_distortion_array():
     assert isinstance(distortion, np.ndarray)
     assert distortion.shape == (8192, 128, 4, 3)
 
-    # Coordinates in m; max x & y should be ~ 12 cm from centre
-    assert .08 < distortion[..., 1].max() < .15
-    assert .08 < distortion[..., 2].max() < .15
+    # Coordinates in m, origin at corner; max x & y should be ~ 25cm
+    assert .20 < distortion[..., 1].max() < .30
+    assert .20 < distortion[..., 2].max() < .30
+    assert -.01 < distortion[..., 1].min() < .01
+    assert -.01 < distortion[..., 2].min() < .01


### PR DESCRIPTION
Generate distortion for LPD and AGIPD detectors

From given geometries for LPD and AGIPD, now we can calculate distortion array of shape (Ny=1024,Nx=1024,Nc=4,3) which can be used for defining detectors in Nexus format (pyFAI compliant too). 