### PR TITLE
Allow selecting region-of-interest in get_array()

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -592,8 +592,9 @@ class DataCollection:
         roi: by_index
             The region of interest. This expression selects data in all
             dimensions apart from the first (trains) dimension. If the data
-            holds a 1D array for each train, roi=by_index[:8] would get the
-            first 8 values from every train.
+            holds a 1D array for each entry, roi=by_index[:8] would get the
+            first 8 values from every train. If the data is 2D or more at
+            each entry, selection looks like roi=by_index[:8, 5:10] .
         """
         self._check_field(source, key)
 

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -256,6 +256,16 @@ def test_file_get_array_missing_trains(mock_sa3_control_data):
     np.testing.assert_array_less(arr.coords['trainId'], 10006)
     np.testing.assert_array_less(10000, arr.coords['trainId'])
 
+def test_file_get_array_control_roi(mock_sa3_control_data):
+    with H5File(mock_sa3_control_data) as f:
+        sel = f.select_trains(by_index[:6])
+        arr = sel.get_array('SA3_XTD10_VAC/DCTRL/D6_APERT_IN_OK',
+                            'interlock.a1.AActCommand.value', roi=by_index[:25])
+
+    assert isinstance(arr, DataArray)
+    assert arr.shape == (6, 25)
+    assert arr.coords['trainId'][0] == 10000
+
 def test_run_get_array(mock_fxe_run):
     run = RunDirectory(mock_fxe_run)
     arr = run.get_array('SA1_XTD2_XGM/DOOCS/MAIN:output', 'data.intensityTD',
@@ -293,6 +303,16 @@ def test_run_get_array_select_trains(mock_fxe_run):
     assert arr.dims == ('trainId', 'pulse')
     assert arr.shape == (50, 1000)
     assert arr.coords['trainId'][0] == 10100
+
+def test_run_get_array_roi(mock_fxe_run):
+    run = RunDirectory(mock_fxe_run)
+    arr = run.get_array('SA1_XTD2_XGM/DOOCS/MAIN:output', 'data.intensityTD',
+                        extra_dims=['pulse'], roi=by_index[:16])
+
+    assert isinstance(arr, DataArray)
+    assert arr.dims == ('trainId', 'pulse')
+    assert arr.shape == (480, 16)
+    assert arr.coords['trainId'][0] == 10000
 
 def test_select(mock_fxe_run):
     run = RunDirectory(mock_fxe_run)


### PR DESCRIPTION
Selecting a 2D region-of-interest would look something like this:

```python
run.get_array('SPB_IRU_INLINEMIC_CAM:daqOutput', 'data.image.pixels',
              roi=by_index[50:100, 20:250])
```

Slices are in the same order as dimensions in the HDF5 file, so probably [y, x] for camera images; this is normal for working with images in arrays. The syntax works for other numbers of dimensions, so you can also select e.g. a 1D region of interest in digitiser data.

Closes gh-100