### PR TITLE
Prototype tree view of sources and keys in a data collection

### DIFF
--- a/karabo_data/htmltree/__init__.py
+++ b/karabo_data/htmltree/__init__.py
@@ -1,0 +1,128 @@
+from htmlgen import (Document, Element, Division, UnorderedList,
+                     ListItem, html_attribute, Link, Script,
+                     )
+from pathlib import Path
+
+_PKGDIR = Path(__file__).parent
+
+class Style(Element):
+    def __init__(self, styles):
+        super().__init__('style')
+        self.children.append_raw(styles)
+
+class Summary(Element):
+    def __init__(self, *content):
+        super().__init__("summary")
+        self.extend(content)
+
+class Details(Element):
+    def __init__(self, *content):
+        super().__init__("details")
+        self.extend(content)
+
+def id_generator(template):
+    n = 0
+    while True:
+        yield template % n
+        n += 1
+
+def make_list(items):
+    ul = UnorderedList()
+    ul.extend(items)
+    return ul
+
+def details_for_key(key, source_name):
+    copylink = Link("#", "[📋]")
+    copylink.set_attribute("data-copy-snippet",
+                           ".get_array({!r}, {!r})".format(source_name, key))
+    copylink.add_css_classes("karabodata-dataset-copylink")
+    copylink.title = "Copy code snippet to get this data"
+    return copylink
+
+def data_collection_node(data):
+    summary = "Collection of {} sources".format(len(data.all_sources))
+    d = Details(Summary(summary), make_list(
+        [source_node(s, data) for s in sorted(data.all_sources)]
+    ))
+    d.set_attribute("open", "")
+    return d
+
+def _nested_insert(nameparts, value, d: dict):
+    head, *tail = nameparts
+    if tail:
+        return _nested_insert(tail, value, d.setdefault(head, {}))
+    d[head] = value
+
+def _format_keys(d: dict):
+    for k, v in sorted(d.items()):
+        if isinstance(v, dict):
+            yield Details(Summary(k), make_list(_format_keys(v)))
+        else:
+            yield ListItem(k, ' ', v)
+
+def source_node(source_name, data):
+    children_d = {}
+    for key in data._keys_for_source(source_name):
+        nameparts = key.split('.')
+        _nested_insert(nameparts, details_for_key(key, source_name), children_d)
+
+    return Details(
+        Summary(source_name),
+        make_list(_format_keys(children_d))
+    )
+
+treeview_ids = id_generator("karabodata-treeview-container-%d")
+
+def make_fragment(data):
+    tree = data_collection_node(data)
+
+    tv = Division(tree)
+    tv.add_css_classes("karabodata-css-treeview")
+    tv.id = next(treeview_ids)
+    return tv
+
+def get_treeview_css():
+    with (_PKGDIR / 'treeview.css').open() as f:
+        return Style(f.read())
+
+JS_ACTIVATE_COPYLINKS_DOC = """
+window.addEventListener("load", function(event) {
+  enable_copylinks(document);
+});
+"""
+
+JS_ACTIVATE_COPYLINKS_FRAG = """
+enable_copylinks(document.getElementById("TREEVIEW-ID"));
+"""
+
+def get_copylinks_js(activation):
+    with (_PKGDIR / "copysnippet.js").open() as f:
+        return f.read().replace("//ACTIVATE", activation)
+
+def make_document(obj):
+    d = Document()
+    d.append_head(get_treeview_css())
+    d.append_head(Script(script=get_copylinks_js(JS_ACTIVATE_COPYLINKS_DOC)))
+    d.title = "karabo_data"
+    d.append_body(make_fragment(obj))
+    return d
+
+def h5obj_to_html(obj):
+    treeview = make_fragment(obj)
+    js_activate = JS_ACTIVATE_COPYLINKS_FRAG.replace("TREEVIEW-ID", treeview.id)
+
+    div = Division(
+        get_treeview_css(),
+        treeview,
+        Script(script=get_copylinks_js(js_activate)),
+    )
+    return str(div)
+
+class DataTree:
+    """View data sources in a Jupyter notebook"""
+    def __init__(self, obj):
+        self.obj = obj
+
+    def _repr_html_(self):
+        return h5obj_to_html(self.obj)
+

--- a/karabo_data/htmltree/copysnippet.js
+++ b/karabo_data/htmltree/copysnippet.js
@@ -1,0 +1,75 @@
+// Based on code by Stackoverflow user Dean Taylor
+// https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript/30810322
+// Used under Stackoverflow's CC-BY-SA 3.0 license
+
+(function() {
+    function copyTextToClipboard(text) {
+        let textArea = document.createElement("textarea");
+
+        //
+        // *** This styling is an extra step which is likely not required. ***
+        //
+        // Why is it here? To ensure:
+        // 1. the element is able to have focus and selection.
+        // 2. if element was to flash render it has minimal visual impact.
+        // 3. less flakyness with selection and copying which **might** occur if
+        //    the textarea element is not visible.
+        //
+        // The likelihood is the element won't even render, not even a flash,
+        // so some of these are just precautions. However in IE the element
+        // is visible whilst the popup box asking the user for permission for
+        // the web page to copy to the clipboard.
+        //
+
+        // Place in top-left corner of screen regardless of scroll position.
+        textArea.style.position = 'fixed';
+        textArea.style.top = 0;
+        textArea.style.left = 0;
+
+        // Ensure it has a small width and height. Setting to 1px / 1em
+        // doesn't work as this gives a negative w/h on some browsers.
+        textArea.style.width = '2em';
+        textArea.style.height = '2em';
+
+        // We don't need padding, reducing the size if it does flash render.
+        textArea.style.padding = 0;
+
+        // Clean up any borders.
+        textArea.style.border = 'none';
+        textArea.style.outline = 'none';
+        textArea.style.boxShadow = 'none';
+
+        // Avoid flash of white box if rendered for any reason.
+        textArea.style.background = 'transparent';
+
+
+        textArea.value = text;
+
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+
+        try {
+            if (!document.execCommand('copy')) {
+                console.log("Unable to copy text with document.execCommand()");
+            }
+        } finally {
+            document.body.removeChild(textArea);
+        }
+    }
+
+    function copy_event_handler(event) {
+        copyTextToClipboard(event.target.dataset.copySnippet);
+        event.preventDefault();
+    }
+
+    function enable_copylinks(parent) {
+        let links = parent.querySelectorAll(".karabodata-dataset-copylink");
+        links.forEach(function (link) {
+            link.addEventListener("click", copy_event_handler);
+        });
+    }
+
+    // The code to actually trigger this is substituted below.
+    //ACTIVATE
+})();

--- a/karabo_data/htmltree/treeview.css
+++ b/karabo_data/htmltree/treeview.css
@@ -1,0 +1,13 @@
+.karabodata-css-treeview summary {
+    display: list-item;
+    cursor: default;
+}
+
+.karabodata-css-treeview ul {
+    margin-top: 0;
+    list-style: none;
+}
+
+.karabodata-css-treeview ul li {
+    margin-bottom: 2px;
+}

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -963,6 +963,10 @@ class DataCollection:
         from .writer import FileWriter
         FileWriter(filename, self).write()
 
+    def view_tree(self):
+        from .htmltree import DataTree
+        return DataTree(self)
+
 class TrainIterator:
     """Iterate over trains in a collection of data
 


### PR DESCRIPTION
Using code from h5glance. Here's what it currently looks like:

![screenshot from 2019-02-08 10-05-52](https://user-images.githubusercontent.com/327925/52471677-5cdcd100-2b89-11e9-8dee-3b2413cbbd92.png)

The copy buttons copy code like:

```python
.get_array('SA3_XTD10_MCP/ADC/1:channel_9.output', 'data.baseline')
```