### PR TITLE
Make keys_for_source method public

### DIFF
--- a/docs/Demo.ipynb
+++ b/docs/Demo.ipynb
@@ -338,12 +338,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This collects data from across files, including detector data:"
+    "See the available keys for a given source:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'data.intensityAUXTD',\n",
+       " 'data.intensitySigma.x_data',\n",
+       " 'data.intensitySigma.y_data',\n",
+       " 'data.intensityTD',\n",
+       " 'data.trainId',\n",
+       " 'data.xTD',\n",
+       " 'data.yTD'}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "run.keys_for_source('SPB_XTD9_XGM/DOOCS/MAIN:output')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This collects data from across files, including detector data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -372,7 +405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {
     "scrolled": true
    },
@@ -420,7 +453,7 @@
        "Name: SA1_XTD2_XGM/DOOCS/MAIN/beamPosition.ixPos, dtype: float32"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -443,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1173,7 +1206,7 @@
        "[480 rows x 4 columns]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1194,7 +1227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1209,11 +1242,11 @@
        "       [0., 0., 0., ..., 0., 0., 0.],\n",
        "       [0., 0., 0., ..., 0., 0., 0.]], dtype=float32)\n",
        "Coordinates:\n",
-       "  * trainId  (trainId) uint64 10000 10001 10002 10003 10004 10005 10006 ...\n",
+       "  * trainId  (trainId) uint64 10000 10001 10002 10003 ... 10477 10478 10479\n",
        "Dimensions without coordinates: pulseID"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1234,7 +1267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1249,7 +1282,7 @@
        "Dimensions without coordinates: pulseID"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1278,7 +1311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1321,7 +1354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {
     "scrolled": false
    },
@@ -1360,7 +1393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1369,7 +1402,7 @@
        "{'dims': (256, 256), 'frames_per_train': 128, 'total_frames': 61440}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1387,7 +1420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1408,7 +1441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1439,36 +1472,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "fxe_example_run : Run directory\r\n",
-      "\r\n",
-      "# of trains:    480\r\n",
-      "Duration:       0:00:47.900000\r\n",
-      "First train ID: 10000\r\n",
-      "Last train ID:  10479\r\n",
-      "\r\n",
-      "16 detector modules (FXE_DET_LPD1M-1)\r\n",
-      "  e.g. module FXE_DET_LPD1M-1 0 : 256 x 256 pixels\r\n",
-      "  128 frames per train, 61440 total frames\r\n",
-      "\r\n",
-      "4 instrument sources (excluding detectors):\r\n",
-      "  - FXE_XAD_GEC/CAM/CAMERA:daqOutput\r\n",
-      "  - FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput\r\n",
-      "  - SA1_XTD2_XGM/DOOCS/MAIN:output\r\n",
-      "  - SPB_XTD9_XGM/DOOCS/MAIN:output\r\n",
-      "\r\n",
-      "4 control sources:\r\n",
-      "  - FXE_XAD_GEC/CAM/CAMERA\r\n",
-      "  - FXE_XAD_GEC/CAM/CAMERA_NODATA\r\n",
-      "  - SA1_XTD2_XGM/DOOCS/MAIN\r\n",
-      "  - SPB_XTD9_XGM/DOOCS/MAIN\r\n",
-      "\r\n"
+      "fxe_example_run : Run directory\n",
+      "\n",
+      "# of trains:    480\n",
+      "Duration:       0:00:47.900000\n",
+      "First train ID: 10000\n",
+      "Last train ID:  10479\n",
+      "\n",
+      "16 detector modules (FXE_DET_LPD1M-1)\n",
+      "  e.g. module FXE_DET_LPD1M-1 0 : 256 x 256 pixels\n",
+      "  128 frames per train, 61440 total frames\n",
+      "\n",
+      "4 instrument sources (excluding detectors):\n",
+      "  - FXE_XAD_GEC/CAM/CAMERA:daqOutput\n",
+      "  - FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput\n",
+      "  - SA1_XTD2_XGM/DOOCS/MAIN:output\n",
+      "  - SPB_XTD9_XGM/DOOCS/MAIN:output\n",
+      "\n",
+      "4 control sources:\n",
+      "  - FXE_XAD_GEC/CAM/CAMERA\n",
+      "  - FXE_XAD_GEC/CAM/CAMERA_NODATA\n",
+      "  - SA1_XTD2_XGM/DOOCS/MAIN\n",
+      "  - SPB_XTD9_XGM/DOOCS/MAIN\n",
+      "\n"
      ]
     }
    ],
@@ -1493,7 +1526,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -374,10 +374,10 @@ class DataCollection:
     def _check_field(self, source, key):
         if source not in self.all_sources:
             raise SourceNameError(source)
-        if key not in self._keys_for_source(source):
+        if key not in self.keys_for_source(source):
             raise PropertyNameError(key, source)
 
-    def _keys_for_source(self, source):
+    def keys_for_source(self, source):
         selected_keys = self.selection[source]
         if selected_keys is not None:
             return selected_keys
@@ -386,6 +386,9 @@ class DataCollection:
         # the same keys in all files that it appears in.
         for f in self._source_index[source]:
             return f.get_keys(source)
+
+    # Leave old name in case anything external was using it:
+    _keys_for_source = keys_for_source
 
     def _check_data_missing(self, tid) -> bool:
         """Return True if a train does not have data for all sources"""
@@ -399,7 +402,7 @@ class DataCollection:
             if file is None:
                 return True
 
-            groups = {k.partition('.')[0] for k in self._keys_for_source(source)}
+            groups = {k.partition('.')[0] for k in self.keys_for_source(source)}
             for group in groups:
                 _, counts = file.get_index(source, group)
                 if counts[pos] == 0:
@@ -488,7 +491,7 @@ class DataCollection:
             if file is None:
                 continue
 
-            for key in self._keys_for_source(source):
+            for key in self.keys_for_source(source):
                 path = '/CONTROL/{}/{}'.format(source, key.replace('.', '/'))
                 source_data[key] = file.file[path][pos]
 
@@ -500,7 +503,7 @@ class DataCollection:
             if file is None:
                 continue
 
-            for key in self._keys_for_source(source):
+            for key in self.keys_for_source(source):
                 group = key.partition('.')[0]
                 firsts, counts = file.get_index(source, group)
                 first, count = firsts[pos], counts[pos]
@@ -618,7 +621,7 @@ class DataCollection:
 
         series = []
         for source in self.all_sources:
-            for key in self._keys_for_source(source):
+            for key in self.keys_for_source(source):
                 if (not timestamps) and key.endswith('.timestamp'):
                     continue
                 series.append(self.get_series(source, key))
@@ -752,7 +755,7 @@ class DataCollection:
                 matched[source] = None
             else:
                 r = ctrl_key_re if source in self.control_sources else key_re
-                keys = set(filter(r.match, self._keys_for_source(source)))
+                keys = set(filter(r.match, self.keys_for_source(source)))
                 if keys:
                     matched[source] = keys
 
@@ -813,7 +816,7 @@ class DataCollection:
                 continue  # Drop the entire source
 
             if keys is None:
-                keys = self._keys_for_source(source)
+                keys = self.keys_for_source(source)
 
             selection[source] = keys - desel_keys
 
@@ -1082,7 +1085,7 @@ class TrainIterator:
             source_data = res[source] = {
                 'metadata': {'source': source, 'timestamp.tid': tid}
             }
-            for key in self.data._keys_for_source(source):
+            for key in self.data.keys_for_source(source):
                 _, pos, ds = self._find_data(source, key, tid)
                 if ds is None:
                     continue
@@ -1092,7 +1095,7 @@ class TrainIterator:
             source_data = res[source] = {
                 'metadata': {'source': source, 'timestamp.tid': tid}
             }
-            for key in self.data._keys_for_source(source):
+            for key in self.data.keys_for_source(source):
                 file, pos, ds = self._find_data(source, key, tid)
                 if ds is None:
                     continue

--- a/karabo_data/writer.py
+++ b/karabo_data/writer.py
@@ -79,11 +79,11 @@ class FileWriter:
         self.file.create_dataset('INDEX/trainId', data=d.train_ids, dtype='u8')
 
         for source in d.control_sources:
-            for key in d._keys_for_source(source):
+            for key in d.keys_for_source(source):
                 self.add_control_dataset(source, key)
 
         for source in d.instrument_sources:
-            for key in d._keys_for_source(source):
+            for key in d.keys_for_source(source):
                 self.add_instrument_dataset(source, key)
 
         self.write_indexes()


### PR DESCRIPTION
As discussed on #109, there should be a public Python API to find the keys for a specified source. There is a method to do this, but it was private. This pull request takes the simple approach of making that method public.