### PR TITLE
Make _find_data_chunks() compatible with numpy 1.14

### DIFF
--- a/karabo_data/read_machinery.py
+++ b/karabo_data/read_machinery.py
@@ -109,6 +109,35 @@ class DataChunk:
         ]
 
 
+# contiguous_regions() by Joe Kington on Stackoverflow
+# https://stackoverflow.com/a/4495197/434217
+# Used here under Stackoverflow's default CC-BY-SA 3.0 license.
+def contiguous_regions(condition):
+    """Finds contiguous True regions of the boolean array "condition". Returns
+    a 2D array where the first column is the start index of the region and the
+    second column is the end index."""
+
+    # Find the indicies of changes in "condition"
+    d = np.diff(condition)
+    idx, = d.nonzero()
+
+    # We need to start things after the change in "condition". Therefore,
+    # we'll shift the index by 1 to the right.
+    idx += 1
+
+    if condition[0]:
+        # If the start of condition is True prepend a 0
+        idx = np.r_[0, idx]
+
+    if condition[-1]:
+        # If the end of condition is True, append the length of the array
+        idx = np.r_[idx, condition.size] # Edit
+
+    # Reshape the result into two columns
+    idx.shape = (-1,2)
+    return idx
+
+
 def union_selections(selections):
     """Merge together different selections
 


### PR DESCRIPTION
This should allow karabo_data to work with the main Anaconda installation on Maxwell, which we broke in 0.3 by using the return_indices parameter to `intersect1d()`.

The contiguous_regions function is already used in `hdf5-virtualise`.

Closes gh-126