### PR TITLE
Write files with virtual datasets

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -58,6 +58,8 @@ including the main detectors, record data more frequently.
 
    .. automethod:: write
 
+   .. automethod:: write_virtual
+
 Missing data
 ------------
 

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -937,6 +937,16 @@ class DataCollection:
         FileWriter(filename, self).write()
 
     def write_virtual(self, filename):
+        """Write an HDF5 file with virtual datasets for the selected data.
+
+        This doesn't copy the data, but each virtual dataset provides a view of
+        data spanning multiple sequence files, which can be accessed as if it
+        had been copied into one big file.
+
+        Creating and reading virtual datasets requires HDF5 version 1.10.
+
+        The target filename will be overwritten if it already exists.
+        """
         from .writer import VirtualFileWriter
         VirtualFileWriter(filename, self).write()
 

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -936,6 +936,10 @@ class DataCollection:
         from .writer import FileWriter
         FileWriter(filename, self).write()
 
+    def write_virtual(self, filename):
+        from .writer import VirtualFileWriter
+        VirtualFileWriter(filename, self).write()
+
 
 class TrainIterator:
     """Iterate over trains in a collection of data

--- a/karabo_data/tests/test_writer.py
+++ b/karabo_data/tests/test_writer.py
@@ -27,11 +27,11 @@ def test_write_selected(mock_fxe_raw_run):
             a = f.get_array('SPB_XTD9_XGM/DOOCS/MAIN:output', 'data.intensityTD')
             assert a.shape == (480, 1000)
 
-def test_write_virtual(mock_fxe_run):
+def test_write_virtual(mock_fxe_raw_run):
     with TemporaryDirectory() as td:
         new_file = osp.join(td, 'test.h5')
 
-        with RunDirectory(mock_fxe_run) as run:
+        with RunDirectory(mock_fxe_raw_run) as run:
             run.write_virtual(new_file)
 
         assert_isfile(new_file)

--- a/karabo_data/tests/test_writer.py
+++ b/karabo_data/tests/test_writer.py
@@ -1,4 +1,6 @@
+import h5py
 import os.path as osp
+import numpy as np
 from tempfile import TemporaryDirectory
 from testpath import assert_isfile
 
@@ -17,6 +19,33 @@ def test_write_selected(mock_fxe_raw_run):
         with H5File(new_file) as f:
             assert f.control_sources == {'SPB_XTD9_XGM/DOOCS/MAIN'}
             assert f.instrument_sources == {'SPB_XTD9_XGM/DOOCS/MAIN:output'}
+
+            s = f.get_series('SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value')
+            # This should have concatenated the two sequence files (400 + 80)
+            assert len(s) == 480
+
+            a = f.get_array('SPB_XTD9_XGM/DOOCS/MAIN:output', 'data.intensityTD')
+            assert a.shape == (480, 1000)
+
+def test_write_virtual(mock_fxe_run):
+    with TemporaryDirectory() as td:
+        new_file = osp.join(td, 'test.h5')
+
+        with RunDirectory(mock_fxe_run) as run:
+            run.write_virtual(new_file)
+
+        assert_isfile(new_file)
+
+        with h5py.File(new_file) as f:
+            ds = f['CONTROL/SPB_XTD9_XGM/DOOCS/MAIN/beamPosition/ixPos/value']
+            assert ds.is_virtual
+
+        with H5File(new_file) as f:
+            np.testing.assert_array_equal(f.train_ids,
+                                      np.arange(10000, 10480, dtype=np.uint64))
+
+            assert 'SPB_XTD9_XGM/DOOCS/MAIN' in f.control_sources
+            assert 'SPB_XTD9_XGM/DOOCS/MAIN:output' in f.instrument_sources
 
             s = f.get_series('SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value')
             # This should have concatenated the two sequence files (400 + 80)

--- a/karabo_data/writer.py
+++ b/karabo_data/writer.py
@@ -31,8 +31,8 @@ class FileWriter:
             assert len(np.unique(data_tids)) == len(data_tids),\
                 "Duplicate train IDs in control data!"
             counts = np.isin(self.data.train_ids, data_tids).astype(np.uint64)
-            ends = np.cumsum(counts)
-            firsts = ends - ends[0]
+            firsts = np.zeros_like(counts)
+            firsts[1:] = np.cumsum(counts)[:-1]  # firsts[0] is always 0
             self.indexes[source] = (firsts, counts)
             self.data_sources.add('CONTROL/' + source)
 
@@ -53,8 +53,8 @@ class FileWriter:
         assert (np.diff(data_tids) >= 0).all(), "Out-of-order train IDs"
         counts = np.array([np.count_nonzero(t == data_tids)
                           for t in self.data.train_ids], dtype=np.uint64)
-        ends = np.cumsum(counts)
-        firsts = ends - ends[0]
+        firsts = np.zeros_like(counts)
+        firsts[1:] = np.cumsum(counts)[:-1]  # firsts[0] is always 0
 
         return firsts, counts
 

--- a/karabo_data/writer.py
+++ b/karabo_data/writer.py
@@ -50,16 +50,13 @@ class FileWriter:
 
     def _generate_index(self, data_tids):
         """Convert an array of train IDs to first/count for each train"""
-        first = np.zeros_like(self.data.train_ids, dtype='u8')
-        count = np.zeros_like(self.data.train_ids, dtype='u8')
+        assert (np.diff(data_tids) >= 0).all(), "Out-of-order train IDs"
+        counts = np.array([np.count_nonzero(t == data_tids)
+                          for t in self.data.train_ids], dtype=np.uint64)
+        ends = np.cumsum(counts)
+        firsts = ends - ends[0]
 
-        for ix, tid in enumerate(self.data.train_ids):
-            matches = (data_tids == tid)
-            if matches.any():
-                first[ix] = matches.nonzero()[0][0]
-                count[ix] = matches.sum()
-
-        return first, count
+        return firsts, counts
 
     def write_indexes(self):
         for groupname, (first, count) in self.indexes.items():

--- a/karabo_data/writer.py
+++ b/karabo_data/writer.py
@@ -111,6 +111,13 @@ class VirtualFileWriter(FileWriter):
     but they provide more convenient access by reassembling data spread over
     several sequence files.
     """
+    def __init__(self, path, data):
+        if not hasattr(h5py, 'VirtualLayout'):
+            raise Exception("Creating virtual datasets requires HDF5 1.10 "
+                            "and h5py 2.9")
+
+        super().__init__(path,  data)
+
     def _assemble_data(self, source, key):
         """Assemble chunks of data into a virtual layout"""
         # First, get a list of all non-empty data chunks

--- a/karabo_data/writer.py
+++ b/karabo_data/writer.py
@@ -19,9 +19,11 @@ class FileWriter:
         a = self.data.get_array(source, key)
         path = 'CONTROL/{}/{}'.format(source, key.replace('.', '/'))
         self.file[path] = a.values
+        self._make_control_index(source)
 
+    def _make_control_index(self, source):
         if source not in self.indexes:
-            n = a.shape[0]
+            n = len(self.data.train_ids)
             self.indexes[source] = \
                 (np.arange(n, dtype='u8'), np.ones(n, dtype='u8'))
             self.data_sources.add('CONTROL/' + source)
@@ -30,10 +32,11 @@ class FileWriter:
         a = self.data.get_array(source, key)
         path = 'INSTRUMENT/{}/{}'.format(source, key.replace('.', '/'))
         self.file[path] = a.values
+        self._make_instrument_index(source, key, a.coords['trainId'].values)
 
+    def _make_instrument_index(self, source, key, data_tids):
         index_path = source + '/' + key.partition('.')[0]
         if index_path not in self.indexes:
-            data_tids = a.coords['trainId'].values
             self.indexes[index_path] = self._generate_index(data_tids)
             self.data_sources.add('INSTRUMENT/' + index_path)
 


### PR DESCRIPTION
Add a `DataCollection.write_virtual()` method to write a file containing virtual datasets for all selected sources. This provides a convenient way to join up the data from several sequence files.

This does *not* attempt to do what `hdf5-virtualise` does - that's a 2D combination along sequence files and across detector modules, which is more complex than the 1D combination here. I do plan to integrate that into karabo_data, but not in this PR.

I've added a test, but I'll try it on real data this afternoon.