### PR TITLE
Deprecate selection parameters in stack_detector_data

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -20,6 +20,7 @@ import os.path as osp
 import pandas as pd
 import re
 import sys
+from warnings import warn
 import xarray
 
 from .exceptions import SourceNameError, PropertyNameError
@@ -1106,14 +1107,19 @@ def stack_detector_data(train, data, axis=-3, modules=16, only='', xcept=()):
     only: str
         Only use devices in train containing this substring.
     xcept: list
-        List of devices to ignore (useful if you have reccored slow data with
-        detector data in the same run).
+        Deprecated: list of devices to ignore, if you have recorded slow data
+        with detector data in the same run).
 
     Returns
     -------
     combined: numpy.array
         Stacked data for requested data path.
     """
+    if xcept:
+        warn("xcept= parameter is deprecated, use data.select() or "
+             "data.deselect() instead before getting a dict.",
+             UserWarning, stacklevel=2)
+
     devices = [dev for dev in train.keys() if only in dev and dev not in xcept]
 
     if not devices:

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1105,7 +1105,7 @@ def stack_detector_data(train, data, axis=-3, modules=16, only='', xcept=()):
     modules: int
         Number of modules composing a detector (default is 16).
     only: str
-        Only use devices in train containing this substring.
+        Deprecated: Only use devices in train containing this substring.
     xcept: list
         Deprecated: list of devices to ignore, if you have recorded slow data
         with detector data in the same run).
@@ -1117,6 +1117,10 @@ def stack_detector_data(train, data, axis=-3, modules=16, only='', xcept=()):
     """
     if xcept:
         warn("xcept= parameter is deprecated, use data.select() or "
+             "data.deselect() instead before getting a dict.",
+             UserWarning, stacklevel=2)
+    if only:
+        warn("only= parameter is deprecated, use data.select() or "
              "data.deselect() instead before getting a dict.",
              UserWarning, stacklevel=2)
 


### PR DESCRIPTION
I want to get rid of these both to simplify the API and to encourage people towards selecting the data of interest before reading it, rather than reading everything and then discarding the unwanted parts. Depending on what data you're looking at, reading data from every source might be very slow.