### PR TITLE
Open run by proposal and run number

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1110,11 +1110,11 @@ def open_run(proposal, run, proc=True):
     raw_files = list((prop_dir / 'raw' / run).glob('*.h5'))
     proc_files = list((prop_dir / 'proc' / run).glob('*.h5'))
 
-    # The first part of the name is RAW or CORR. After trimming that,
-    # ignore raw files with a corresponding file in proc.
-    got_in_proc = {p.name.split('-', 1)[1] for p in proc_files}
+    # Names look like RAW-R0243-AGIPD10-S00002.h5 . If the 3rd part ('AGIPD10')
+    # exists in proc, skip loading it from raw.
+    got_in_proc = {p.name.split('-')[2] for p in proc_files}
     raw_files = [p for p in raw_files
-                 if p.name.split('-', 1)[1] not in got_in_proc]
+                 if p.name.split('-')[2] not in got_in_proc]
 
     files = proc_files + raw_files
     if not files:

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -17,6 +17,7 @@ from glob import glob
 import h5py
 import logging
 import numpy as np
+import os
 import os.path as osp
 import pandas as pd
 import re
@@ -1096,8 +1097,13 @@ def open_run(proposal, run, proc=True):
 
     raw_dir = osp.join(prop_dir, 'raw', run)
     proc_dir = osp.join(prop_dir, 'proc', run)
-    raw_files = glob(osp.join(raw_dir, '*.h5'))
-    proc_files = glob(osp.join(proc_dir, '*.h5'))
+
+    # Not using glob here because it suppresses errors when you don't have
+    # permission to list the files.
+    raw_files = [e.path for e in os.scandir(raw_dir)
+                 if e.is_file() and e.name.endswith('.h5')]
+    proc_files = [e.path for e in os.scandir(proc_dir)
+                 if e.is_file() and e.name.endswith('.h5')]
 
     # Names look like RAW-R0243-AGIPD10-S00002.h5 . If the 3rd part ('AGIPD10')
     # exists in proc, skip loading it from raw.

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1073,8 +1073,11 @@ def open_run(proposal, run, proc=True):
     run: str, int
         A run number such as 243, '243' or 'r0243'.
     proc: bool
-        If True (default), combine data from the raw and 'proc' (processed)
-        folders for the specified run. If False, access only the raw data.
+        If True (default), open files from the 'proc' (processed) data folder,
+        and raw data files where there isn't a corresponding processed file.
+        Files which do not need post-processing are not copied to proc, so
+        this combination is necessary to include all data sources for the run.
+        If False, open only the raw data files.
     """
     if isinstance(proposal, int):
         proposal = 'p{:06d}'.format(proposal)

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1094,8 +1094,10 @@ def open_run(proposal, run, proc=True):
     if not proc:
         return RunDirectory(osp.join(prop_dir, 'raw', run))
 
-    raw_files = glob(osp.join(prop_dir, 'raw', run, '*.h5'))
-    proc_files = glob(osp.join(prop_dir, 'proc', run, '*.h5'))
+    raw_dir = osp.join(prop_dir, 'raw', run)
+    proc_dir = osp.join(prop_dir, 'proc', run)
+    raw_files = glob(osp.join(raw_dir, '*.h5'))
+    proc_files = glob(osp.join(proc_dir, '*.h5'))
 
     # Names look like RAW-R0243-AGIPD10-S00002.h5 . If the 3rd part ('AGIPD10')
     # exists in proc, skip loading it from raw.
@@ -1105,8 +1107,8 @@ def open_run(proposal, run, proc=True):
 
     files = proc_files + raw_files
     if not files:
-        raise Exception("No .h5 files found for proposal {!r} run {!r}"
-                        .format(proposal, run))
+        raise Exception("No .h5 files found in {!r} or {!r}"
+                        .format(raw_dir, proc_dir))
 
     return DataCollection.from_paths(files)
 

--- a/karabo_data/tests/test_read_machinery.py
+++ b/karabo_data/tests/test_read_machinery.py
@@ -1,0 +1,14 @@
+import os
+import os.path as osp
+from unittest import mock
+
+from karabo_data import read_machinery
+
+def test_find_proposal(tmpdir):
+    prop_dir = osp.join(tmpdir, 'SPB', '201701', 'p002012')
+    os.makedirs(prop_dir)
+
+    with mock.patch.object(read_machinery, 'DATA_ROOT_DIR', tmpdir):
+        assert read_machinery.find_proposal('p002012') == prop_dir
+
+        assert read_machinery.find_proposal(prop_dir) == prop_dir

--- a/karabo_data/tests/test_read_machinery.py
+++ b/karabo_data/tests/test_read_machinery.py
@@ -8,7 +8,7 @@ def test_find_proposal(tmpdir):
     prop_dir = osp.join(str(tmpdir), 'SPB', '201701', 'p002012')
     os.makedirs(prop_dir)
 
-    with mock.patch.object(read_machinery, 'DATA_ROOT_DIR', tmpdir):
+    with mock.patch.object(read_machinery, 'DATA_ROOT_DIR', str(tmpdir)):
         assert read_machinery.find_proposal('p002012') == prop_dir
 
         assert read_machinery.find_proposal(prop_dir) == prop_dir

--- a/karabo_data/tests/test_read_machinery.py
+++ b/karabo_data/tests/test_read_machinery.py
@@ -5,7 +5,7 @@ from unittest import mock
 from karabo_data import read_machinery
 
 def test_find_proposal(tmpdir):
-    prop_dir = osp.join(tmpdir, 'SPB', '201701', 'p002012')
+    prop_dir = osp.join(str(tmpdir), 'SPB', '201701', 'p002012')
     os.makedirs(prop_dir)
 
     with mock.patch.object(read_machinery, 'DATA_ROOT_DIR', tmpdir):

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -588,7 +588,7 @@ def test_open_run(mock_spb_raw_run, mock_spb_proc_run, tmpdir):
     os.makedirs(os.path.join(prop_dir, 'proc'))
     os.symlink(mock_spb_proc_run, os.path.join(prop_dir, 'proc', 'r0238'))
 
-    with mock.patch('karabo_data.read_machinery.DATA_ROOT_DIR', tmpdir):
+    with mock.patch('karabo_data.read_machinery.DATA_ROOT_DIR', str(tmpdir)):
         # With integers
         run = open_run(proposal=2012, run=238)
         paths = {f.filename for f in run.files}

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -579,7 +579,7 @@ def test_run_immutable_sources(mock_fxe_raw_run):
 
 
 def test_open_run(mock_spb_raw_run, mock_spb_proc_run, tmpdir):
-    prop_dir = os.path.join(tmpdir, 'SPB', '201830', 'p002012')
+    prop_dir = os.path.join(str(tmpdir), 'SPB', '201830', 'p002012')
     # Set up raw
     os.makedirs(os.path.join(prop_dir, 'raw'))
     os.symlink(mock_spb_raw_run, os.path.join(prop_dir, 'raw', 'r0238'))

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -593,31 +593,21 @@ def test_open_run(mock_spb_raw_run, mock_spb_proc_run, tmpdir):
         run = open_run(proposal=2012, run=238)
         paths = {f.filename for f in run.files}
 
-        # Should have both AGIPD files from proc/ and other data from raw/
-        agipd_paths = {f for f in paths if 'AGIPD' in f}
-        assert agipd_paths
-        for path in agipd_paths:
-            assert '/proc/' in path
-
-        control_paths = paths - agipd_paths
-        assert control_paths
-        for path in control_paths:
+        assert paths
+        for path in paths:
             assert '/raw/' in path
 
         # With strings
         run = open_run(proposal='2012', run='238')
         assert {f.filename for f in run.files} == paths
 
-        # Don't read proc data
-        run = open_run(proposal=2012, run=238, proc=False)
-        raw_only_paths = {f.filename for f in run.files}
-        assert raw_only_paths.issuperset(control_paths)
-        assert raw_only_paths.isdisjoint(agipd_paths)
+        # Proc folder
+        run = open_run(proposal=2012, run=238, data='proc')
 
-        raw_agipd_paths = {f for f in raw_only_paths if 'AGIPD' in f}
-        assert raw_agipd_paths
-        for path in raw_agipd_paths:
-            assert '/raw/' in path
+        proc_paths = {f.filename for f in run.files}
+        assert proc_paths
+        for path in proc_paths:
+            assert '/raw/' not in path
 
         # Run that doesn't exist
         with pytest.raises(Exception):


### PR DESCRIPTION
Add a new `open_run` function which can look up a run's data by proposal and run number:

```python
run = open_run(proposal=2012, run=238)
```

The proposal is looked up by scanning the instrument and cycle directories; this wastes a bit of time, but probably not much. The user can pass a proposal directory path to avoid this. And we could implement a caching mechanism later if it's an issue.

By default, it tries to combine data from raw and proc, with data in proc taking precedence where possible. This can be overridden with `proc=False` to only use raw data.

I'm not 100% sure about the way raw data is selected when combining raw+proc. Currently, it excludes any raw files for which the 3rd part of the filename (like `AGIPD05` or `DA02`) matches something in proc. But if e.g. one AGIPD module doesn't get calibrated for some reason, it will load raw data for that module and proc data for the others, which will cause problems if you later try to combine them. I don't think there's any way around that without hardcoding some specific rules about AGIPD/LPD/DSSC.