### PR TITLE
Create virtual CXI files

### DIFF
--- a/docs/agipd_lpd_data.rst
+++ b/docs/agipd_lpd_data.rst
@@ -17,6 +17,8 @@ pulling together the separate modules into a single array.
 
    .. automethod:: trains
 
+   .. automethod:: write_virtual_cxi
+
 .. seealso::
 
    :doc:`lpd_data`: An example using the class above.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,59 @@
+Command line tools
+==================
+
+``lsxfel``
+----------
+
+Examine the contents of an EuXFEL proposal directory, run directory, or HDF5
+file:
+
+.. code-block:: shell
+
+   # Proposal directory
+   lsxfel /gpfs/exfel/exp/XMPL/201750/p700000
+
+   # Run directory
+   lsxfel /gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002
+
+   # Single file
+   lsxfel /gpfs/exfel/exp/XMPL/201750/p700000/proc/r0002/CORR-R0034-AGIPD00-S00000.h5
+
+
+``karabo-data-validate``
+------------------------
+
+Check the structure of an EuXFEL run or HDF5 file:
+
+.. code-block:: shell
+
+   karabo-data-validate /gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002
+
+If it finds problems with the data, the program will produce a list of them and
+exit with status 1.
+
+``karabo-bridge-serve-files``
+-----------------------------
+
+Stream data from files in the `Karabo bridge
+<https://in.xfel.eu/readthedocs/docs/data-analysis-user-documentation/en/latest/online.html#data-stream-to-user-tools>`_
+format. See :doc:`streaming` for more information.
+
+``karabo-data-make-virtual-cxi``
+--------------------------------
+
+Make a virtual CXI file to access AGIPD/LPD detector data from a specified run:
+
+.. code-block:: shell
+
+   karabo-data-make-virtual-cxi /gpfs/exfel/exp/XMPL/201750/p700000/proc/r0003 -o xmpl-3.cxi
+
+.. program:: karabo-data-make-virtual-cxi
+
+.. option:: -o <path>, --output <path>
+
+   The filename to write. Defaults to creating a file in the proposal's
+   scratch directory.
+
+.. option:: --min-modules <number>
+
+   Include trains where at least N modules have data (default 9).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Contents:
    streaming
    validation
    geometry
+   cli
    data_format
 
 .. toctree::

--- a/karabo_data/cli/__init__.py
+++ b/karabo_data/cli/__init__.py
@@ -1,0 +1,1 @@
+"""karabo_data command-line interfaces"""

--- a/karabo_data/cli/make_virtual_cxi.py
+++ b/karabo_data/cli/make_virtual_cxi.py
@@ -1,0 +1,76 @@
+import argparse
+import logging
+import os
+import os.path as osp
+import re
+import sys
+
+from karabo_data import RunDirectory
+from karabo_data.components import AGIPD1M, LPD1M
+from karabo_data.exceptions import SourceNameError
+
+
+def _get_detector(data, min_modules):
+    for cls in (AGIPD1M, LPD1M):
+        try:
+            return cls(data, min_modules=min_modules)
+        except SourceNameError:
+            continue
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser('karabo-data-make-virtual-cxi')
+    ap.add_argument('run_dir', help="Path to an EuXFEL run directory")
+    # Specifying a proposal directory & a run number is the older interface.
+    # If the run_number argument is passed, run_dir is used as proposal.
+    ap.add_argument('run_number', nargs="?", help=argparse.SUPPRESS)
+    ap.add_argument(
+        '-o', '--output',
+        help="Filename or path for the CXI output file. "
+             "By default, it is written in the proposal's scratch directory."
+    )
+    ap.add_argument(
+        '--min-modules', type=int, default=9, metavar='N',
+        help="Include trains where at least N modules have data (default 9)"
+    )
+    args = ap.parse_args(argv)
+    out_file = args.output
+
+    logging.basicConfig(level=logging.INFO)
+
+    if args.run_number:
+        # proposal directory, run number
+        run  = 'r%04d' % int(args.run_number)
+        proposal = args.run_dir
+        run_dir = osp.join(args.run_dir, 'proc', run)
+        if out_file is None:
+            out_file = osp.join(proposal, 'scratch', '{}_detectors_virt.cxi'.format(run))
+
+    else:
+        # run directory
+        run_dir = os.path.abspath(args.run_dir)
+        if out_file is None:
+            m = re.search(r'/proc/(r\d{4})/?$', run_dir)
+            if not m:
+                sys.exit("ERROR: '-o outfile' option needed when "
+                         "input directory doesn't look like .../proc/r0123")
+            proposal = run_dir[:m.start()]
+            out_file = osp.join(proposal, 'scratch',
+                                '{}_detectors_virt.cxi'.format(m.group(1)))
+
+    out_dir = osp.dirname(osp.abspath(out_file))
+
+    if not os.access(run_dir, os.R_OK):
+        sys.exit("ERROR: Don't have read access to {}".format(run_dir))
+    if not os.access(out_dir, os.W_OK):
+        sys.exit("ERROR: Don't have write access to {}".format(out_dir))
+
+    run = RunDirectory(args.run_dir)
+    det = _get_detector(run, args.min_modules)
+    if det is None:
+        sys.exit("No AGIPD or LPD sources found in {!r}".format(args.run_dir))
+
+    det.write_virtual_cxi(out_file)
+
+if __name__ == '__main__':
+    main()

--- a/karabo_data/cli/make_virtual_cxi.py
+++ b/karabo_data/cli/make_virtual_cxi.py
@@ -65,10 +65,10 @@ def main(argv=None):
     if not os.access(out_dir, os.W_OK):
         sys.exit("ERROR: Don't have write access to {}".format(out_dir))
 
-    run = RunDirectory(args.run_dir)
+    run = RunDirectory(run_dir)
     det = _get_detector(run, args.min_modules)
     if det is None:
-        sys.exit("No AGIPD or LPD sources found in {!r}".format(args.run_dir))
+        sys.exit("No AGIPD or LPD sources found in {!r}".format(run_dir))
 
     det.write_virtual_cxi(out_file)
 

--- a/karabo_data/cli/make_virtual_cxi.py
+++ b/karabo_data/cli/make_virtual_cxi.py
@@ -50,13 +50,13 @@ def main(argv=None):
         # run directory
         run_dir = os.path.abspath(args.run_dir)
         if out_file is None:
-            m = re.search(r'/proc/(r\d{4})/?$', run_dir)
+            m = re.search(r'/(raw|proc)/(r\d{4})/?$', run_dir)
             if not m:
                 sys.exit("ERROR: '-o outfile' option needed when "
                          "input directory doesn't look like .../proc/r0123")
             proposal = run_dir[:m.start()]
-            out_file = osp.join(proposal, 'scratch',
-                                '{}_detectors_virt.cxi'.format(m.group(1)))
+            fname = '{}_{}_detectors_virt.cxi'.format(*m.group(2, 1))
+            out_file = osp.join(proposal, 'scratch', fname)
 
     out_dir = osp.dirname(osp.abspath(out_file))
 

--- a/karabo_data/components.py
+++ b/karabo_data/components.py
@@ -6,6 +6,7 @@ import pandas as pd
 import re
 import xarray
 
+from .exceptions import SourceNameError
 from .reader import DataCollection, by_id, by_index
 
 log = logging.getLogger(__name__)
@@ -126,7 +127,7 @@ class MPxDetectorBase:
             if m:
                 detector_names.add(m.group(1))
         if not detector_names:
-            raise ValueError("No detector sources found in this data")
+            raise SourceNameError(cls._source_re.pattern)
         elif len(detector_names) > 1:
             raise ValueError(
                 "Multiple detectors found in the data: {}. "
@@ -150,7 +151,7 @@ class MPxDetectorBase:
                                if n in modules}
 
         if not source_to_modno:
-            raise ValueError("No detector sources found in this data")
+            raise SourceNameError(detector_re.pattern)
 
         return source_to_modno
 

--- a/karabo_data/components.py
+++ b/karabo_data/components.py
@@ -94,10 +94,12 @@ class MPxDetectorBase:
         self.detector_name = detector_name
         self.source_to_modno = source_to_modno
 
+        # pandas' missing-data handling converts the data to floats if there
+        # are any gaps - so fill them with 0s and convert back to uint64.
         mod_data_counts = pd.DataFrame({
             src: data.get_data_counts(src, 'image.data')
             for src in source_to_modno
-        })
+        }).fillna(0).astype(np.uint64)
 
         # Sanity check: all non-zero counts should be equal
         data_count_values = set(mod_data_counts.values.flatten()) - {0}

--- a/karabo_data/components.py
+++ b/karabo_data/components.py
@@ -81,6 +81,7 @@ class MPxDetectorBase:
     """
 
     _source_re = re.compile(r'(?P<detname>.+)/DET/(\d+)CH')
+    module_shape = (0, 0)  # Override in subclass
 
     def __init__(self, data: DataCollection, detector_name=None, modules=None,
                  *, min_modules=1):
@@ -342,6 +343,21 @@ class MPxDetectorBase:
         pulses = _check_pulse_selection(pulses)
         return MPxDetectorTrainIterator(self, pulses)
 
+    def write_virtual_cxi(self, filename):
+        """Write a virtual CXI file to access the detector data.
+
+        The virtual datasets in the file provide a view of the detector
+        data as if it was a single huge array, but without copying the data.
+        Creating and using virtual datasets requires HDF5 1.10.
+
+        Parameters
+        ----------
+        filename: str
+          The file to be written. Will be overwritten if it already exists.
+        """
+        from .write_cxi import VirtualCXIWriter
+        VirtualCXIWriter(self).write(filename)
+
 
 class MPxDetectorTrainIterator:
     """Iterate over trains in detector data, assembling arrays.
@@ -516,6 +532,7 @@ class AGIPD1M(MPxDetectorBase):
       Include trains where at least n modules have data. Default is 1.
     """
     _source_re = re.compile(r'(?P<detname>(.+)_AGIPD1M(.*))/DET/(\d+)CH')
+    module_shape = (512, 128)
 
 
 class LPD1M(MPxDetectorBase):
@@ -536,3 +553,4 @@ class LPD1M(MPxDetectorBase):
       Include trains where at least n modules have data. Default is 1.
     """
     _source_re = re.compile(r'(?P<detname>(.+)_LPD1M(.*))/DET/(\d+)CH')
+    module_shape = (256, 256)

--- a/karabo_data/components.py
+++ b/karabo_data/components.py
@@ -107,6 +107,8 @@ class MPxDetectorBase:
         if len(data_count_values) > 1:
             raise ValueError("Inconsistent frame counts: {}"
                              .format(data_count_values))
+        elif not data_count_values:
+            raise ValueError("No data found for selected sources")
 
         self.frames_per_train = data_count_values.pop()
         self.data = self._select_trains(data, mod_data_counts, min_modules)

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -423,6 +423,27 @@ class DataCollection:
         train_id = self.train_ids[train_index]
         return self.train_from_id(int(train_id), devices=devices)
 
+    def get_data_counts(self, source, key):
+        """Get a count of data points in each train
+
+        Returns a pandas series with an index of train IDs.
+        """
+        self._check_field(source, key)
+        seq_series = []
+
+        for f in self._source_index[source]:
+            if source in self.control_sources:
+                counts = np.ones(f.train_ids, dtype=np.uint64)
+            else:
+                group = key.partition('.')[0]
+                _, counts = f.get_index(source, group)
+            seq_series.append(pd.Series(counts, index=f.train_ids))
+
+        ser = pd.concat(sorted(seq_series, key=lambda s: s.index[0]))
+        # Select out only the train IDs of interest
+        train_ids = ser.index.intersection(self.train_ids)
+        return ser.loc[train_ids]
+
     def get_series(self, source, key):
         """Return a pandas Series for a particular data field.
 

--- a/karabo_data/tests/cli/test_make_virtual_cxi.py
+++ b/karabo_data/tests/cli/test_make_virtual_cxi.py
@@ -1,0 +1,20 @@
+import os
+import os.path as osp
+from testpath import assert_isfile
+
+from karabo_data.cli.make_virtual_cxi import main
+
+def test_make_virtual_cxi(mock_spb_proc_run, tmpdir):
+    output = osp.join(str(tmpdir), 'test.cxi')
+    main([mock_spb_proc_run, '-o', output])
+    assert_isfile(output)
+
+def test_make_virtual_cxi_runno(mock_spb_proc_run, tmpdir):
+    proc = osp.join(str(tmpdir), 'proc')
+    os.mkdir(proc)
+    os.symlink(mock_spb_proc_run, osp.join(proc, 'r0238'))
+    output = osp.join(str(tmpdir), 'test.cxi')
+
+    # Pass proposal directory and run number
+    main([str(tmpdir), '238', '-o', output])
+    assert_isfile(output)

--- a/karabo_data/tests/conftest.py
+++ b/karabo_data/tests/conftest.py
@@ -49,25 +49,25 @@ def mock_spb_control_data_badname():
         yield path
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def mock_fxe_raw_run():
     with TemporaryDirectory() as td:
         make_examples.make_fxe_run(td)
         yield td
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def mock_spb_proc_run():
     with TemporaryDirectory() as td:
         make_examples.make_spb_run(td, raw=False)
         yield td
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def mock_spb_raw_run():
     with TemporaryDirectory() as td:
         make_examples.make_spb_run(td)
         yield td
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def empty_h5_file():
     with TemporaryDirectory() as td:
         path = osp.join(td, 'empty.h5')

--- a/karabo_data/tests/test_components.py
+++ b/karabo_data/tests/test_components.py
@@ -125,6 +125,18 @@ def test_write_virtual_cxi(mock_spb_proc_run, tmpdir):
         assert ds.shape[1:] == (16, 512, 128)
         assert 'axes' in ds.attrs
 
+        assert len(ds.virtual_sources()) == 16
+
+        # Check position of each source file in the modules dimension
+        for src in ds.virtual_sources():
+            start, _, block, count = src.vspace.get_regular_hyperslab()
+            assert block[1] == 1
+            assert count[1] == 1
+
+            expected_file = 'CORR-R0238-AGIPD{:0>2}-S00000.h5'.format(start[1])
+            assert osp.basename(src.file_name) == expected_file
+
+        # Check presence of other datasets
         assert 'gain' in det_grp
         assert 'mask' in det_grp
         assert 'experiment_identifier' in det_grp

--- a/karabo_data/tests/test_components.py
+++ b/karabo_data/tests/test_components.py
@@ -1,3 +1,5 @@
+import h5py
+import numpy as np
 import os.path as osp
 import pytest
 from testpath import assert_isfile
@@ -114,6 +116,18 @@ def test_write_virtual_cxi(mock_spb_proc_run, tmpdir):
     test_file = osp.join(str(tmpdir), 'test.cxi')
     det.write_virtual_cxi(test_file)
     assert_isfile(test_file)
+
+    with h5py.File(test_file) as f:
+        det_grp = f['entry_1/instrument_1/detector_1']
+        ds = det_grp['data']
+        assert isinstance(ds, h5py.Dataset)
+        assert ds.is_virtual
+        assert ds.shape[1:] == (16, 512, 128)
+        assert 'axes' in ds.attrs
+
+        assert 'gain' in det_grp
+        assert 'mask' in det_grp
+        assert 'experiment_identifier' in det_grp
 
 def test_write_virtual_cxi_raw_data(mock_fxe_raw_run, tmpdir, caplog):
     import logging

--- a/karabo_data/tests/test_components.py
+++ b/karabo_data/tests/test_components.py
@@ -114,3 +114,13 @@ def test_write_virtual_cxi(mock_spb_proc_run, tmpdir):
     test_file = osp.join(str(tmpdir), 'test.cxi')
     det.write_virtual_cxi(test_file)
     assert_isfile(test_file)
+
+def test_write_virtual_cxi_raw_data(mock_fxe_raw_run, tmpdir, caplog):
+    import logging
+    caplog.set_level(logging.INFO)
+    run = RunDirectory(mock_fxe_raw_run)
+    det = LPD1M(run)
+
+    test_file = osp.join(str(tmpdir), 'test.cxi')
+    det.write_virtual_cxi(test_file)
+    assert_isfile(test_file)

--- a/karabo_data/tests/test_components.py
+++ b/karabo_data/tests/test_components.py
@@ -1,7 +1,9 @@
+import os.path as osp
 import pytest
+from testpath import assert_isfile
 
 from karabo_data.reader import RunDirectory, by_id, by_index
-from karabo_data.components import LPD1M
+from karabo_data.components import AGIPD1M, LPD1M
 
 
 def test_get_array(mock_fxe_raw_run):
@@ -104,3 +106,11 @@ def test_iterate_pulse_index(mock_fxe_raw_run):
     tid, d = next(iter(det.trains(pulses=by_index[[1, 7, 22, 23]])))
     assert d['image.data'].shape == (16, 1, 4, 256, 256)
     assert list(d['image.data'].coords['pulse']) == [1, 7, 22, 23]
+
+def test_write_virtual_cxi(mock_spb_proc_run, tmpdir):
+    run = RunDirectory(mock_spb_proc_run)
+    det = AGIPD1M(run)
+
+    test_file = osp.join(str(tmpdir), 'test.cxi')
+    det.write_virtual_cxi(test_file)
+    assert_isfile(test_file)

--- a/karabo_data/write_cxi.py
+++ b/karabo_data/write_cxi.py
@@ -2,11 +2,6 @@
 import h5py
 import logging
 import numpy as np
-import sys
-
-from . import RunDirectory
-from .exceptions import SourceNameError
-from .components import AGIPD1M, LPD1M
 
 log = logging.getLogger(__name__)
 
@@ -176,72 +171,3 @@ class VirtualCXIWriter:
             dgrp.create_dataset('module_identifier', data=self.modulenos)
 
         log.info("Finished writing virtual CXI file")
-
-def _get_detector(data, min_modules):
-    for cls in (AGIPD1M, LPD1M):
-        try:
-            return cls(data, min_modules=min_modules)
-        except SourceNameError:
-            continue
-
-def main(argv=None):
-    import argparse
-    import os
-    import os.path as osp
-    import re
-
-    ap = argparse.ArgumentParser('karabo-data-make-virtual-cxi')
-    ap.add_argument('run_dir', help="Path to an EuXFEL run directory")
-    # Specifying a proposal directory & a run number is the older interface.
-    # If the run_number argument is passed, run_dir is used as proposal.
-    ap.add_argument('run_number', nargs="?", help=argparse.SUPPRESS)
-    ap.add_argument(
-        '-o', '--output',
-        help="Filename or path for the CXI output file. "
-             "By default, it is written in the proposal's scratch directory."
-    )
-    ap.add_argument(
-        '--min-modules', type=int, default=9, metavar='N',
-        help="Include trains where at least N modules have data (default 9)"
-    )
-    args = ap.parse_args(argv)
-    out_file = args.output
-
-    logging.basicConfig(level=logging.INFO)
-
-    if args.run_number:
-        # proposal directory, run number
-        run  = 'r%04d' % int(args.run_number)
-        proposal = args.run_dir
-        run_dir = osp.join(args.run_dir, 'proc', run)
-        if out_file is None:
-            out_file = osp.join(proposal, 'scratch', '{}_detectors_virt.cxi'.format(run))
-
-    else:
-        # run directory
-        run_dir = os.path.abspath(args.run_dir)
-        if out_file is None:
-            m = re.search(r'/proc/(r\d{4})/?$', run_dir)
-            if not m:
-                sys.exit("ERROR: '-o outfile' option needed when "
-                         "input directory doesn't look like .../proc/r0123")
-            proposal = run_dir[:m.start()]
-            out_file = osp.join(proposal, 'scratch',
-                                '{}_detectors_virt.cxi'.format(m.group(1)))
-
-    out_dir = osp.dirname(osp.abspath(out_file))
-
-    if not os.access(run_dir, os.R_OK):
-        sys.exit("ERROR: Don't have read access to {}".format(run_dir))
-    if not os.access(out_dir, os.W_OK):
-        sys.exit("ERROR: Don't have write access to {}".format(out_dir))
-
-    run = RunDirectory(args.run_dir)
-    det = _get_detector(run, args.min_modules)
-    if det is None:
-        sys.exit("No AGIPD or LPD sources found in {!r}".format(args.run_dir))
-
-    det.write_virtual_cxi(out_file)
-
-if __name__ == '__main__':
-    main()

--- a/karabo_data/write_cxi.py
+++ b/karabo_data/write_cxi.py
@@ -38,9 +38,13 @@ class VirtualCXIWriter:
 
         for i, source in enumerate(self.detdata.source_to_modno):
             for chunk in self.data._find_data_chunks(source, 'image.pulseId'):
-                ix = self.train_id_to_ix[chunk.train_ids[0]]
-                n = chunk.counts.sum()
+                # Expand the list of train IDs to one per frame
                 chunk_tids = np.repeat(chunk.train_ids, chunk.counts.astype(np.intp))
+
+                # Look up where this chunk fits in the output
+                ix = self.train_id_to_ix[chunk_tids[0]]
+                n = chunk.counts.sum()
+
                 if (chunk_tids != self.train_ids_perframe[ix: ix + n]).any():
                     raise Exception(
                         "Train IDs mismatch in chunk from source {} "

--- a/karabo_data/write_cxi.py
+++ b/karabo_data/write_cxi.py
@@ -186,27 +186,62 @@ def _get_detector(data, min_modules):
 
 def main(argv=None):
     import argparse
+    import os
+    import os.path as osp
+    import re
 
     ap = argparse.ArgumentParser('karabo-data-make-virtual-cxi')
     ap.add_argument('run_dir', help="Path to an EuXFEL run directory")
+    # Specifying a proposal directory & a run number is the older interface.
+    # If the run_number argument is passed, run_dir is used as proposal.
+    ap.add_argument('run_number', nargs="?", help=argparse.SUPPRESS)
     ap.add_argument(
         '-o', '--output',
-        help="Filename or path for the CXI output file."
+        help="Filename or path for the CXI output file. "
+             "By default, it is written in the proposal's scratch directory."
     )
     ap.add_argument(
         '--min-modules', type=int, default=9, metavar='N',
         help="Include trains where at least N modules have data (default 9)"
     )
     args = ap.parse_args(argv)
+    out_file = args.output
 
     logging.basicConfig(level=logging.INFO)
+
+    if args.run_number:
+        # proposal directory, run number
+        run  = 'r%04d' % int(args.run_number)
+        proposal = args.run_dir
+        run_dir = osp.join(args.run_dir, 'proc', run)
+        if out_file is None:
+            out_file = osp.join(proposal, 'scratch', '{}_detectors_virt.cxi'.format(run))
+
+    else:
+        # run directory
+        run_dir = os.path.abspath(args.run_dir)
+        if out_file is None:
+            m = re.search(r'/proc/(r\d{4})/?$', run_dir)
+            if not m:
+                sys.exit("ERROR: '-o outfile' option needed when "
+                         "input directory doesn't look like .../proc/r0123")
+            proposal = run_dir[:m.start()]
+            out_file = osp.join(proposal, 'scratch',
+                                '{}_detectors_virt.cxi'.format(m.group(1)))
+
+    out_dir = osp.dirname(osp.abspath(out_file))
+
+    if not os.access(run_dir, os.R_OK):
+        sys.exit("ERROR: Don't have read access to {}".format(run_dir))
+    if not os.access(out_dir, os.W_OK):
+        sys.exit("ERROR: Don't have write access to {}".format(out_dir))
 
     run = RunDirectory(args.run_dir)
     det = _get_detector(run, args.min_modules)
     if det is None:
         sys.exit("No AGIPD or LPD sources found in {!r}".format(args.run_dir))
 
-    det.write_virtual_cxi(args.output)
+    det.write_virtual_cxi(out_file)
 
 if __name__ == '__main__':
     main()

--- a/karabo_data/write_cxi.py
+++ b/karabo_data/write_cxi.py
@@ -171,3 +171,29 @@ class VirtualCXIWriter:
             dgrp.create_dataset('module_identifier', data=self.modulenos)
 
         log.info("Finished writing virtual CXI file")
+
+def main(argv=None):
+    import argparse
+    from karabo_data import RunDirectory
+    from karabo_data.components import AGIPD1M
+
+    ap = argparse.ArgumentParser('karabo-data-make-virtual-cxi')
+    ap.add_argument('run_dir', help="Path to an EuXFEL run directory")
+    ap.add_argument(
+        '-o', '--output',
+        help="Filename or path for the CXI output file."
+    )
+    ap.add_argument(
+        '--min-modules', type=int, default=9, metavar='N',
+        help="Include trains where at least N modules have data (default 9)"
+    )
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO)
+
+    run = RunDirectory(args.run_dir)
+    det = AGIPD1M(run, min_modules=args.min_modules)
+    det.write_virtual_cxi(args.output)
+
+if __name__ == '__main__':
+    main()

--- a/karabo_data/write_cxi.py
+++ b/karabo_data/write_cxi.py
@@ -6,6 +6,23 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 class VirtualCXIWriter:
+    """Machinery to write a CXI file containing virtual datasets.
+
+    You don't normally need to use this class directly. Instead,
+    use the write_virtual_cxi() method on an AGIPD/LPD data interface object.
+
+    CXI specifies a particular layout of data in the HDF5 file format.
+    It is documented here:
+    http://www.cxidb.org/cxi.html
+
+    This code writes version 1.5 CXI files.
+
+    Parameters
+    ----------
+
+    detdata: karabo_data.components.MPxDetectorBase
+      The detector data interface for the data to gather in this file.
+    """
     def __init__(self, detdata):
         self.detdata = detdata
 

--- a/karabo_data/write_cxi.py
+++ b/karabo_data/write_cxi.py
@@ -1,0 +1,147 @@
+"""Writing CXI files from AGIPD/LPD data"""
+import h5py
+import logging
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+class VirtualCXIWriter:
+    def __init__(self, detdata):
+        self.detdata = detdata
+
+        self.nmodules = len(detdata.modno_to_source)
+        self.modulenos = sorted(detdata.modno_to_source)
+
+        train_ids = detdata.train_ids
+        frames_per_train = detdata.frames_per_train
+        ntrains = np.uint64(len(train_ids))
+        self.nframes = ntrains * frames_per_train
+        log.info("%d frames per train, %d frames in total",
+                     frames_per_train, self.nframes)
+        self.shape = (self.nframes, self.nmodules) + detdata.module_shape
+        log.info("Virtual data shape: %r", self.shape)
+
+        self.train_ids_perframe = np.repeat(train_ids, frames_per_train)
+
+        positions = np.arange(0, ntrains, dtype=np.uint64) * frames_per_train
+        self.train_id_to_ix = dict(zip(train_ids, positions))
+
+    @property
+    def data(self):
+        return self.detdata.data
+
+    def collect_pulse_ids(self):
+        # Gather pulse IDs
+        NO_PULSE_ID = 9999
+        pulse_ids = np.full((self.nmodules, self.nframes), NO_PULSE_ID,
+                            dtype=np.uint64)
+
+        for i, source in enumerate(self.detdata.source_to_modno):
+            for chunk in self.data._find_data_chunks(source, 'image.pulseId'):
+                ix = self.train_id_to_ix[chunk.train_ids[0]]
+                n = chunk.counts.sum()
+                chunk_tids = np.repeat(chunk.train_ids, chunk.counts.astype(np.intp))
+                if (chunk_tids != self.train_ids_perframe[ix: ix + n]).any():
+                    raise Exception(
+                        "Train IDs mismatch in chunk from source {} "
+                        "({} frames from train ID {})"
+                            .format(source, n, chunk_tids[0])
+                    )
+                # In some cases, there's an extra dimension of length 1
+                if chunk.dataset.ndim > 1:
+                    chunk_pulse_ids = chunk.dataset[chunk.slice, 0]
+                else:
+                    chunk_pulse_ids = chunk.dataset[chunk.slice]
+                pulse_ids[i, ix: ix + n] = chunk_pulse_ids
+
+        # Sanity checks on pulse IDs
+        pulse_ids_min = pulse_ids.min(axis=0)
+        if (pulse_ids_min == NO_PULSE_ID).any():
+            raise Exception("Failed to find pulse IDs for some data")
+        pulse_ids[pulse_ids == NO_PULSE_ID] = 0
+        if (pulse_ids_min != pulse_ids.max(axis=0)).any():
+            raise Exception("Inconsistent pulse IDs for different modules")
+
+        # Pulse IDs make sense. Drop the modules dimension, giving one pulse ID
+        # for each frame.
+        return pulse_ids_min
+
+    def collect_data(self):
+        src = next(iter(self.detdata.source_to_modno))
+        h5file = self.data._source_index[src][0].file
+        image_grp = h5file['INSTRUMENT'][src]['image']
+
+        layouts = {
+            'data': h5py.VirtualLayout(self.shape, dtype=image_grp['data'].dtype),
+            'gain': h5py.VirtualLayout(self.shape, dtype=image_grp['gain'].dtype),
+            'mask': h5py.VirtualLayout(self.shape, dtype=image_grp['mask'].dtype),
+            'cellId': h5py.VirtualLayout((self.nframes, self.nmodules),
+                                         dtype=image_grp['data'].dtype),
+        }
+
+        for name, layout in layouts.items():
+            key = 'image.{}'.format(name)
+            nchunks = 0
+            have_data = np.zeros((self.nframes, self.nmodules), dtype=bool)
+            for source, modno in self.detdata.source_to_modno.items():
+                mod_ix = self.modulenos.index(modno)
+                for chunk in self.data._find_data_chunks(source, key):
+                    ix = self.train_id_to_ix[chunk.train_ids[0]]
+                    n = chunk.counts.sum()
+                    vsrc = h5py.VirtualSource(chunk.dataset)
+                    layout[ix:ix+n, mod_ix] = vsrc[chunk.slice]
+
+                    have_data[ix:ix+n, mod_ix] = True
+                    nchunks += 1
+
+            filled_pct = 100 * have_data.sum() / have_data.size
+            log.info("Assembled %d chunks for %s, filling %.2f%% of the hyperslab",
+                     nchunks, key, filled_pct)
+
+        return layouts
+
+    def write(self, filename):
+        pulse_ids = self.collect_pulse_ids()
+        experiment_ids = np.core.defchararray.add(np.core.defchararray.add(
+            self.train_ids_perframe.astype(str), ':'), pulse_ids.astype(str))
+
+        layouts = self.collect_data()
+
+        log.info("Writing to %s", filename)
+
+        with h5py.File(filename, 'w', libver='latest') as f:
+            f.create_dataset('cxi_version', data=[150])
+            d = f.create_dataset('entry_1/experiment_identifier',
+                                 shape=experiment_ids.shape,
+                                 dtype=h5py.special_dtype(vlen=str))
+            d[:] = experiment_ids
+
+            # pulseId, trainId, cellId are not part of the CXI standard, but
+            # it allows extra data.
+            f.create_dataset('entry_1/pulseId', data=pulse_ids)
+            f.create_dataset('entry_1/trainId', data=self.train_ids_perframe)
+            cellids = f.create_virtual_dataset('entry_1/cellId',
+                                               layouts['cellId'])
+            cellids.attrs['axes'] = 'experiment_identifier:module_identifier'
+
+
+            dgrp = f.create_group('entry_1/instrument_1/detector_1')
+            data = dgrp.create_virtual_dataset(
+                'data', layouts['data'], fillvalue=np.nan
+            )
+            data.attrs['axes'] = 'experiment_identifier:module_identifier:y:x'
+            gain = dgrp.create_virtual_dataset(
+                'gain', layouts['gain'], fillvalue=np.nan
+            )
+            gain.attrs['axes'] = 'experiment_identifier:module_identifier:y:x'
+            mask = dgrp.create_virtual_dataset(
+                'mask', layouts['mask'], fillvalue=np.nan
+            )
+            mask.attrs['axes'] = 'experiment_identifier:module_identifier:y:x'
+            dgrp['experiment_identifier'] = h5py.SoftLink('/entry_1/experiment_identifier')
+
+            f['entry_1/data_1'] = h5py.SoftLink('/entry_1/instrument_1/detector_1')
+
+            dgrp.create_dataset('module_identifier', data=self.modulenos)
+
+        log.info("Finished writing virtual CXI file")

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name="karabo_data",
               "lsxfel = karabo_data.lsxfel:main",
               "karabo-bridge-serve-files = karabo_data.export:main",
               "karabo-data-validate = karabo_data.validation:main",
-              "karabo-data-make-virtual-cxi = karabo_data.write_cxi:main"
+              "karabo-data-make-virtual-cxi = karabo_data.cli.make_virtual_cxi:main"
           ],
       },
       install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(name="karabo_data",
               "lsxfel = karabo_data.lsxfel:main",
               "karabo-bridge-serve-files = karabo_data.export:main",
               "karabo-data-validate = karabo_data.validation:main",
+              "karabo-data-make-virtual-cxi = karabo_data.write_cxi:main"
           ],
       },
       install_requires=[


### PR DESCRIPTION
Adds a `write_virtual_cxi` method to the AGIPD & LPD data access classes. This should provide the same functionality as `hdf5-virtualise` but more flexible. I plan to ultimately add a command-line wrapper as well.

This also includes:

- A parameter for a minimum number of modules to include a train. For the command-line interface, I plan to have a default of 9, excluding the trains where only half of the detector is working (see discussion on #144).
- A new method `get_data_counts` to get a pandas series of the number of data points for a source in each train (fixing #112).

Still to do:

- [x] Test on some real data
- [x] Command line interface
  - [x] Matching hdf5-virtualise capabilities
- [x] Accept raw data
- [x] Docs