### PR TITLE
'On demand' virtual datasets

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Contents:
    examine_geometry
    agipd_geometry
    xpd_examples
+   parallel_example
 
 .. toctree::
    :caption: Development

--- a/docs/parallel_example.ipynb
+++ b/docs/parallel_example.ipynb
@@ -1,0 +1,466 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parallel processing with a virtual dataset\n",
+    "\n",
+    "This example demonstrates splitting up some data to be processed by several worker processes, and collecting the results back together.\n",
+    "\n",
+    "For this example, we'll use data from an XGM, and find the average intensity of each pulse across all the trains in the run. This doesn't actually need parallel processing: we can easily do it directly in the notebook. But the same techniques should work with much more data and more complex calculations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from karabo_data import RunDirectory\n",
+    "import multiprocessing\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The data that we want is separated over these seven sequence files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002/RAW-R0034-DA01-S00000.h5\r\n",
+      "/gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002/RAW-R0034-DA01-S00001.h5\r\n",
+      "/gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002/RAW-R0034-DA01-S00002.h5\r\n",
+      "/gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002/RAW-R0034-DA01-S00003.h5\r\n",
+      "/gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002/RAW-R0034-DA01-S00004.h5\r\n",
+      "/gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002/RAW-R0034-DA01-S00005.h5\r\n",
+      "/gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002/RAW-R0034-DA01-S00006.h5\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls /gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002/RAW-R0034-DA01-S*.h5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run = RunDirectory('/gpfs/exfel/exp/XMPL/201750/p700000/raw/r0002/')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By making a virtual dataset, we can see the shape of it, as if it was one big numpy array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<HDF5 dataset \"intensityTD\": shape (3391, 1000), type \"<f4\">"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vds_filename = 'xgm_vds.h5'\n",
+    "xgm_vds = run.get_virtual_dataset(\n",
+    "    'SA1_XTD2_XGM/XGM/DOOCS:output', 'data.intensityTD',\n",
+    "    filename=vds_filename\n",
+    ")\n",
+    "xgm_vds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's read this into memory and calculate the means directly, to check our parallel calculations against.\n",
+    "We can do this for this example because the calculation is simple and the data is small;\n",
+    "it wouldn't be practical in real situations where parallelisation is useful.\n",
+    "\n",
+    "These data are recorded in 32-bit floats, but to minimise rounding errors we'll tell numpy to give the results as 64-bit floats. Try re-running this example with 32-bit floats to see how much the results change!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([834.2744, 860.0754, 869.2637, 891.4351, 899.6227, 899.3759,\n",
+       "       900.3555, 899.1162, 898.4991, 904.4979, 910.5669, 914.1612,\n",
+       "       922.5737, 925.8734, 930.093 , 935.3124, 938.9643, 941.4609,\n",
+       "       946.1351, 950.6574, 951.855 , 954.2491, 956.6414, 957.5584,\n",
+       "       961.7528, 961.1457, 958.9655, 957.6415, 953.8603, 947.9236,\n",
+       "         0.    ,   0.    ,   0.    ,   0.    ,   0.    ,   0.    ,\n",
+       "         0.    ,   0.    ,   0.    ,   0.    ])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simple_mean = xgm_vds[:, :40].mean(axis=0, dtype=np.float64)\n",
+    "simple_mean.round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we're going to define chunks of the data for each of 4 worker processes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(0, 847), (847, 1695), (1695, 2543), (2543, 3391)]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "N_proc = 4\n",
+    "cuts = [int(xgm_vds.shape[0] * i / N_proc) for i in range(N_proc + 1)]\n",
+    "chunks = list(zip(cuts[:-1], cuts[1:]))\n",
+    "chunks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using `multiprocessing`\n",
+    "\n",
+    "This is the function we'll ask each worker process to run, adding up the data and returning a 1D numpy array.\n",
+    "\n",
+    "We're using default arguments as a convenient way to copy the filename and the dataset path into the worker process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sum_chunk(chunk, filename=vds_filename, ds_name=xgm_vds.name):\n",
+    "    start, end = chunk\n",
+    "    # Reopen the file in the worker process:\n",
+    "    import h5py, numpy\n",
+    "    with h5py.File(filename, 'r') as f:\n",
+    "        ds = f[ds_name]\n",
+    "        data = ds[start:end]  # Read my chunk\n",
+    "    \n",
+    "    return data.sum(axis=0, dtype=numpy.float64)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using Python's `multiprocessing` module, we start four workers, farm the chunks out to them, and collect the results back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with multiprocessing.Pool(N_proc) as pool:\n",
+    "    res = pool.map(sum_chunk, chunks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`res` is now a list of 4 arrays, containing the sums from each chunk. To get the mean, we'll add these up to get a grand total, and then divide by the number of trains we have data from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([834.2744, 860.0754, 869.2637, 891.4351, 899.6227, 899.3759,\n",
+       "       900.3555, 899.1162, 898.4991, 904.4979, 910.5669, 914.1612,\n",
+       "       922.5737, 925.8734, 930.093 , 935.3124, 938.9643, 941.4609,\n",
+       "       946.1351, 950.6574, 951.855 , 954.2491, 956.6414, 957.5584,\n",
+       "       961.7528, 961.1457, 958.9655, 957.6415, 953.8603, 947.9236,\n",
+       "         0.    ,   0.    ,   0.    ,   0.    ,   0.    ,   0.    ,\n",
+       "         0.    ,   0.    ,   0.    ,   0.    ])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multiproc_mean = (np.stack(res).sum(axis=0, dtype=np.float64)[:40] / xgm_vds.shape[0])\n",
+    "np.testing.assert_allclose(multiproc_mean, simple_mean)\n",
+    "\n",
+    "multiproc_mean.round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using SLURM\n",
+    "\n",
+    "What if we need more power? The example above is limited to one machine, but we can use SLURM to spread the work over multiple machines on the [Maxwell cluster](https://confluence.desy.de/display/IS/Maxwell).\n",
+    "\n",
+    "This is massive overkill for this example calculation - we'll only use one CPU core for a fraction of a second on each machine. But we could do something similar for a much bigger problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from getpass import getuser\n",
+    "import h5py\n",
+    "import subprocess"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll write a Python script for each worker to run. Like the `sum_chunk` function above, this reads a chunk of data from the virtual dataset and sums it along the train axis. It saves the result into another HDF5 file for us to collect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing parallel_eg_worker.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile parallel_eg_worker.py\n",
+    "#!/gpfs/exfel/sw/software/xfel_anaconda3/1.1/bin/python\n",
+    "import h5py\n",
+    "import numpy as np\n",
+    "import sys\n",
+    "\n",
+    "filename = sys.argv[1]\n",
+    "ds_name = sys.argv[2]\n",
+    "chunk_start = int(sys.argv[3])\n",
+    "chunk_end = int(sys.argv[4])\n",
+    "worker_idx = sys.argv[5]\n",
+    "\n",
+    "with h5py.File(filename, 'r') as f:\n",
+    "    ds = f[ds_name]\n",
+    "    data = ds[chunk_start:chunk_end]  # Read my chunk\n",
+    "\n",
+    "chunk_totals = data.sum(axis=0, dtype=np.float64)\n",
+    "\n",
+    "with h5py.File(f'parallel_eg_result_{worker_idx}.h5', 'w') as f:\n",
+    "    f['chunk_totals'] = chunk_totals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Maxwell cluster is divided into various partitions for different groups of users. If you're running this as an external user, comment out the 'Staff' line below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partition = 'upex'   # External users\n",
+    "partition = 'exfel'  # Staff"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we submit 4 jobs with the `sbatch` command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b'Submitted batch job 2631813\\n'\n",
+      "b'Submitted batch job 2631814\\n'\n",
+      "b'Submitted batch job 2631815\\n'\n",
+      "b'Submitted batch job 2631816\\n'\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i, (start, end) in enumerate(chunks):\n",
+    "    cmd = ['sbatch', '-p', partition, 'parallel_eg_worker.py', vds_filename, xgm_vds.name, str(start), str(end), str(i)]\n",
+    "    print(subprocess.check_output(cmd))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use `squeue` to monitor the jobs running. Re-run this until all the jobs have disappeared, meaning they're finished."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!squeue -u {getuser()}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, so long as all the workers succeeded, we can collect the results.\n",
+    "\n",
+    "If any workers failed, you'll find tracebacks in `slurm-*.out` files in the working directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = []\n",
+    "\n",
+    "for i in range(N_proc):\n",
+    "    with h5py.File(f'parallel_eg_result_{i}.h5', 'r') as f:\n",
+    "        res.append(f['chunk_totals'][:])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now `res` is once again a list of 1D numpy arrays, representing the totals from each chunk. So we can finish the calculation as in the previous section:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([834.2744, 860.0754, 869.2637, 891.4351, 899.6227, 899.3759,\n",
+       "       900.3555, 899.1162, 898.4991, 904.4979, 910.5669, 914.1612,\n",
+       "       922.5737, 925.8734, 930.093 , 935.3124, 938.9643, 941.4609,\n",
+       "       946.1351, 950.6574, 951.855 , 954.2491, 956.6414, 957.5584,\n",
+       "       961.7528, 961.1457, 958.9655, 957.6415, 953.8603, 947.9236,\n",
+       "         0.    ,   0.    ,   0.    ,   0.    ,   0.    ,   0.    ,\n",
+       "         0.    ,   0.    ,   0.    ,   0.    ])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "slurm_mean = np.stack(res).sum(axis=0)[:40] / xgm_vds.shape[0]\n",
+    "np.testing.assert_allclose(slurm_mean, simple_mean)\n",
+    "\n",
+    "slurm_mean.round(4)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "xfel",
+   "language": "python",
+   "name": "xfel-1.1"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -54,6 +54,10 @@ including the main detectors, record data more frequently.
 
    .. automethod:: get_array
 
+   .. automethod:: get_virtual_dataset
+
+      .. versionadded:: 0.5
+
    .. automethod:: select
 
    .. automethod:: deselect

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -995,30 +995,33 @@ class DataCollection:
         from .writer import VirtualFileWriter
         VirtualFileWriter(filename, self).write()
 
-    def get_virtual_dataset(self, source, key):
+    def get_virtual_dataset(self, source, key, filename=None):
         """Create an HDF5 virtual dataset for a given source & key
 
         A dataset looks like a multidimensional array, but the data is loaded
         on-demand when you access it. So it's suitable as an
         interface to data which is too big to load entirely into memory.
 
-        This returns an h5py.Dataset object. This exists in a real temporary
-        file as a 'virtual dataset', a collection of links pointing to the
-        data in real datasets. The file path is available as ``ds.file.name``,
-        and the path of the dataset inside the file as ``ds.name``.
+        This returns an h5py.Dataset object. This exists in a real file as a
+        'virtual dataset', a collection of links pointing to the data in real
+        datasets. If *filename* is passed, the file is written at that path,
+        overwriting if it already exists. Otherwise, it uses a new temp file.
 
-        The temporary file may be cleaned up when this process exits, and will
-        probably not be visible from other machines. If you want to access the
-        data for longer or from other systems, for instance for distributed
-        data processing, you can copy the temporary file to another location.
-        It should be a small file, as it only points to the real data. However,
-        it will only be usable where you have access to the original data files.
+        To access the dataset from other worker processes, give them the name
+        of the created file along with the path to the dataset inside it
+        (accessible as ``ds.name``). They will need at least HDF5 1.10 to access
+        the virtual dataset, and they must be on a system with access to the
+        original data files, as the virtual dataset points to those.
         """
         self._check_field(source, key)
 
         from .writer import VirtualFileWriter
-        fd, filename = tempfile.mkstemp(suffix='-karabo-data-vds.h5')
-        os.close(fd)
+
+        if filename is None:
+            # Make a temp file to hold the virtual dataset.
+            fd, filename = tempfile.mkstemp(suffix='-karabo-data-vds.h5')
+            os.close(fd)
+
         vfw = VirtualFileWriter(filename, self)
 
         vfw.write_train_ids()

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -5,6 +5,7 @@ import numpy as np
 import os
 import pandas as pd
 import pytest
+from testpath import assert_isfile
 from unittest import mock
 from xarray import DataArray
 
@@ -403,6 +404,19 @@ def test_run_get_virtual_dataset(mock_fxe_raw_run):
     assert isinstance(ds, h5py.Dataset)
     assert ds.is_virtual
     assert ds.shape == (480, 255, 1024)
+
+
+def test_run_get_virtual_dataset_filename(mock_fxe_raw_run, tmp_path):
+    run = RunDirectory(mock_fxe_raw_run)
+    path = str(tmp_path / 'test-vds.h5')
+    ds = run.get_virtual_dataset(
+        'FXE_DET_LPD1M-1/DET/6CH0:xtdf', 'image.data', filename=path
+    )
+    assert_isfile(path)
+    assert ds.file.filename == path
+    assert isinstance(ds, h5py.Dataset)
+    assert ds.is_virtual
+    assert ds.shape == (61440, 1, 256, 256)
 
 
 def test_select(mock_fxe_raw_run):

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -406,9 +406,9 @@ def test_run_get_virtual_dataset(mock_fxe_raw_run):
     assert ds.shape == (480, 255, 1024)
 
 
-def test_run_get_virtual_dataset_filename(mock_fxe_raw_run, tmp_path):
+def test_run_get_virtual_dataset_filename(mock_fxe_raw_run, tmpdir):
     run = RunDirectory(mock_fxe_raw_run)
-    path = str(tmp_path / 'test-vds.h5')
+    path = str(tmpdir / 'test-vds.h5')
     ds = run.get_virtual_dataset(
         'FXE_DET_LPD1M-1/DET/6CH0:xtdf', 'image.data', filename=path
     )

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -1,5 +1,6 @@
 from itertools import islice
 
+import h5py
 import numpy as np
 import os
 import pandas as pd
@@ -386,6 +387,22 @@ def test_run_get_array_multiple_per_train(mock_fxe_raw_run):
     assert isinstance(arr, DataArray)
     assert arr.shape == (256, 1, 10, 20)
     np.testing.assert_array_equal(arr.coords['trainId'], np.repeat([10000, 10001], 128))
+
+
+def test_run_get_virtual_dataset(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    ds = run.get_virtual_dataset('FXE_DET_LPD1M-1/DET/6CH0:xtdf', 'image.data')
+    assert isinstance(ds, h5py.Dataset)
+    assert ds.is_virtual
+    assert ds.shape == (61440, 1, 256, 256)
+
+    # Across two sequence files
+    ds = run.get_virtual_dataset(
+        'FXE_XAD_GEC/CAM/CAMERA:daqOutput', 'data.image.pixels'
+    )
+    assert isinstance(ds, h5py.Dataset)
+    assert ds.is_virtual
+    assert ds.shape == (480, 255, 1024)
 
 
 def test_select(mock_fxe_raw_run):

--- a/karabo_data/writer.py
+++ b/karabo_data/writer.py
@@ -58,6 +58,10 @@ class FileWriter:
 
         return firsts, counts
 
+    def write_train_ids(self):
+        d = self.data
+        self.file.create_dataset('INDEX/trainId', data=d.train_ids, dtype='u8')
+
     def write_indexes(self):
         for groupname, (first, count) in self.indexes.items():
             self.file['INDEX/{}/first'.format(groupname)] = first
@@ -90,7 +94,7 @@ class FileWriter:
 
     def write(self):
         d = self.data
-        self.file.create_dataset('INDEX/trainId', data=d.train_ids, dtype='u8')
+        self.write_train_ids()
 
         for source in d.control_sources:
             for key in d.keys_for_source(source):
@@ -159,6 +163,7 @@ class VirtualFileWriter(FileWriter):
         self.file.create_virtual_dataset(path, layout)
 
         self._make_control_index(source, train_ids)
+        return path
 
     def add_instrument_dataset(self, source, key):
         layout, train_ids = self._assemble_data(source, key)
@@ -169,3 +174,4 @@ class VirtualFileWriter(FileWriter):
         self.file.create_virtual_dataset(path, layout)
 
         self._make_instrument_index(source, key, train_ids)
+        return path

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --ignore docs/apply_geometry.ipynb --ignore docs/xpd_examples.ipynb --ignore "docs/agipd_geometry.ipynb" --ignore docs/xgm_two_runs.ipynb
+addopts = --ignore docs/apply_geometry.ipynb --ignore docs/xpd_examples.ipynb --ignore "docs/agipd_geometry.ipynb" --ignore docs/xgm_two_runs.ipynb --ignore docs/parallel_example.ipynb


### PR DESCRIPTION
This adds a `data.get_virtual_dataset(source, key)` method, similar to `get_array()`, which creates and returns a virtual dataset for a single data field. This doesn't load the data into memory, so it's practical for accessing large amounts of data.

For instance, you could create a virtual dataset, see the shape of the data as if it was one giant array, and then tell multiple worker processes to each process a different chunk of that data.

(The virtual datasets for now are just stitching together sequence files for a single data source, not joining multiple detector modules. But we could add a similar interface for that later.)

