### PR TITLE
Quick fix: Check if data.mask exists

### DIFF
--- a/karabo_data/write_cxi.py
+++ b/karabo_data/write_cxi.py
@@ -127,8 +127,10 @@ class VirtualCXIWriter:
             layouts = {
                 'data': VLayout(shape, dtype=image_grp['data'].dtype),
                 'gain': VLayout(shape, dtype=image_grp['gain'].dtype),
-                'mask': VLayout(shape, dtype=image_grp['mask'].dtype),
             }
+
+            if 'mask' in image_grp:
+                layouts['mask'] = VLayout(shape, dtype=image_grp['mask'].dtype)
         else:
             log.info("Identified raw data")
 


### PR DESCRIPTION
We ran into the problem of write_cxi failing because the LPD data has no mask entry. This very minor PR should check if a mask is existing. 