### PR TITLE
Move crystFEL related methods to base class.

### DIFF
--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -277,40 +277,40 @@ class DetectorGeometryBase:
             path to the group that contains the mask array in the hdf5 file
 
         dims : collection, default : ('frame', 'modno', 'ss', 'fs')
-            Dimensions of the data. Extra dimensios, except for details are
-            added by thier index. The dimensions should contain frame, modno,
+            Dimensions of the data. Extra dimensions, except for the defaults,
+            should be added by therr index e.g ('frame', 'modno', 0, 'ss', 'fs)
+            for raw data. Note: the dimensions must contain frame, modno,
             ss, fs.
 
-        adu_per_ev : float, default : 0.0075
+        adu_per_ev : float
             ADU (analog digital units) per electron volt for the considered
             detector.
 
-        clen : float, default : 0.119
+        clen : float
             Distance between sample and detector in meters
 
-        photon_energy : int, default : 9800
+        photon_energy
             Beam wave length in eV
         """
         from . import __version__
 
         if adu_per_ev is None:
-            warnings.warn('adu_per_ev must be set; Setting to default value')
             adu_per_ev_str = '; adu_per_eV = SET ME'
             # TODO: adu_per_ev should be fixed for each detector, we should 
             #       find out the values and set them.
         else:
             adu_per_ev_str = 'adu_per_eV = {}'.format(adu_per_ev)
+
         if clen is None:
             clen_str = '; clen = SET ME'
-            warnings.warn('clen must be set; Setting to default value')
         else:
             clen_str = 'clen = {}'.format(clen)
+
         if photon_energy is None:
             photon_energy_str = '; photon_energy = SET ME'
-            warnings.warn('photon_energy must be set, setting to default value')
         else:
             photon_energy_str = 'photon_energy = {}'.format(photon_energy)
-        
+
         # Get the frame dimension
         tile_dims = {}
 

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -246,8 +246,24 @@ class DetectorGeometryBase:
         rigid_string += 'rigid_group_collection_asics = {}\n\n'.format(modules)
         return rigid_string
 
-    def write_crystfel_geom(self, filename):
-        """Write this geometry to a CrystFEL format (.geom) geometry file."""
+    def write_crystfel_geom(self, filename, adu_per_ev=0.0075, clen=0.119,
+                            photon_energy=10235):
+        """Write this geometry to a CrystFEL format (.geom) geometry file.
+        Parameters
+        ----------
+        filename : str
+        filename of the geometry file
+
+        Keywords
+        --------
+        adu_per_ev : float
+        ADU (analog digital units) per electron volt for the considered 
+        detector (default 0.0075).
+        clen : float
+        Distance between sample and detector in meters (default 0.119)
+        photon_energy : int
+        Beam wave length in eV (default 10235)
+        """
         from . import __version__
 
         panel_chunks = []
@@ -257,7 +273,10 @@ class DetectorGeometryBase:
         pix_size = self.pixel_size * 1e6 # Convert pixels size to microns
         with open(filename, 'w') as f:
             f.write(CRYSTFEL_HEADER_TEMPLATE.format(version=__version__,
-                                                    pix_size=pix_size))
+                                                    pix_size=pix_size,
+                                                    adu_per_ev=adu_per_ev,
+                                                    clen=clen,
+                                                    photon_energy=photon_energy))
             rigid_groups = self._get_rigid_groups()
             f.write(rigid_groups)
             for chunk in panel_chunks:
@@ -804,9 +823,9 @@ CRYSTFEL_HEADER_TEMPLATE = """\
 
 dim0 = %
 res = {pix_size} ;
-photon_energy = 10235 ;
-clen = 0.119  ; Camera length, aka detector distance
-adu_per_eV = 0.0075  ; no idea
+photon_energy = {photon_energy} ;
+clen = {clen}  ; Camera length, aka detector distance
+adu_per_eV = {adu_per_ev}; no idea
 
 """
 

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -217,7 +217,7 @@ class DetectorGeometryBase:
 
         return ax
 
-    def _tile_dims(self, modno, tileno):
+    def _tile_dims(self, tileno):
         """Implement in subclass: which part of module array each tile is.
         """
         raise NotImplementedError
@@ -278,7 +278,7 @@ class DetectorGeometryBase:
 
         dims : collection, default : ('frame', 'modno', 'ss', 'fs')
             Dimensions of the data. Extra dimensions, except for the defaults,
-            should be added by therr index e.g ('frame', 'modno', 0, 'ss', 'fs)
+            should be added by their index e.g ('frame', 'modno', 0, 'ss', 'fs)
             for raw data. Note: the dimensions must contain frame, modno,
             ss, fs.
 
@@ -325,7 +325,7 @@ class DetectorGeometryBase:
         panel_chunks = []
         for p, module in enumerate(self.modules):
             for a, fragment in enumerate(module):
-                ss_dims, fs_dims = self._tile_dims(p, a)
+                ss_dims, fs_dims = self._tile_dims(a)
                 panel_chunks.append(fragment.to_crystfel_geom(p,
                                                               a,
                                                               ss_dims,
@@ -774,11 +774,7 @@ class AGIPD_1MGeometry(DetectorGeometryBase):
         return ss_slice, fs_slice
 
     @classmethod
-    def _tile_dims(cls, modno, tileno):
-        # Which part of the array is this tile?
-
-        #min_ss=(a * self.ss_pixels),
-        #max_ss=(((a + 1) * self.ss_pixels) - 1),
+    def _tile_dims(cls, tileno):
         tile_offset = tileno * cls.frag_ss_pixels
         ss_dims = tile_offset, tile_offset + cls.frag_ss_pixels - 1
         fs_dims = 0, cls.frag_fs_pixels - 1 # Every tile covers the full pixel range
@@ -1164,7 +1160,7 @@ class LPD_1MGeometry(DetectorGeometryBase):
         return super().to_distortion_array()  # Overridden only for docstring
 
     @classmethod
-    def _tile_dims(cls, moduleno, tileno):
+    def _tile_dims(cls, tileno):
         if tileno < 8: # First half of module (0 <= t <=7)
             fs_dims = 0, 127
             tiles_up = 7 - tileno
@@ -1354,7 +1350,7 @@ class DSSC_Geometry(DetectorGeometryBase):
         return ss_slice, fs_slice
 
     @classmethod
-    def _tile_dims(cls, modno, tileno):
+    def _tile_dims(cls, tileno):
         tile_offset = tileno * cls.frag_fs_pixels
         fs_dims = tile_offset, tile_offset + cls.frag_fs_pixels - 1
         ss_dims = 0, cls.frag_ss_pixels - 1# Every tile covers the full pixel range

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -278,9 +278,9 @@ class DetectorGeometryBase:
 
         dims : collection, default : ('frame', 'modno', 'ss', 'fs')
             Dimensions of the data. Extra dimensions, except for the defaults,
-            should be added by their index e.g ('frame', 'modno', 0, 'ss', 'fs)
-            for raw data. Note: the dimensions must contain frame, modno,
-            ss, fs.
+            should be added by their index, e.g.
+            ('frame', 'modno', 0, 'ss', 'fs') for raw data.
+            Note: the dimensions must contain frame, modno, ss, fs.
 
         adu_per_ev : float
             ADU (analog digital units) per electron volt for the considered

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -70,6 +70,7 @@ class GeometryFragment:
             p=p,
             min_ss=(a * self.ss_pixels),
             max_ss=(((a + 1) * self.ss_pixels) - 1),
+            max_fs=self.fs_pixels,
             ss_vec=_crystfel_format_vec(self.ss_vec),
             fs_vec=_crystfel_format_vec(self.fs_vec),
             corner_x=c[0],
@@ -816,7 +817,7 @@ CRYSTFEL_PANEL_TEMPLATE = """
 {name}/dim3 = fs
 {name}/min_fs = 0
 {name}/min_ss = {min_ss}
-{name}/max_fs = 127
+{name}/max_fs = {max_fs}
 {name}/max_ss = {max_ss}
 {name}/fs = {fs_vec}
 {name}/ss = {ss_vec}

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -239,7 +239,7 @@ class DetectorGeometryBase:
         return cls(modules, filename=filename)
 
     def _get_rigid_groups(self, nquads=4):
-        """Create ridget stings for rigid groups definiton."""
+        """Create rigid stings for rigid groups definiton."""
 
         quads = ','.join(['q{}'.format(q) for q in range(nquads)])
         modules = ','.join(['p{}'.format(p) for p in range(self.n_modules)])
@@ -264,8 +264,8 @@ class DetectorGeometryBase:
                             mask_path=None, extra_dim=None, *, filename,
                             adu_per_ev, clen, photon_energy):
         """Write this geometry to a CrystFEL format (.geom) geometry file.
-        Keywords
-        --------
+        Parameters
+        ----------
         data_path  : (str)
             path to the group that contains the data array in the hdf5 file
             (default : /entry_1/instrument_1/detector_1/data)

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -909,7 +909,7 @@ class LPD_1MGeometry(DetectorGeometryBase):
         panels_across = [-1, -1, 0, 0]
         panels_up = [0, -1, -1, 0]
         modules = []
-        for p in range(self.n_modules):
+        for p in range(cls.n_modules):
             quad = p // 4
             quad_corner_x = quad_pos[quad][0] * px_conversion
             quad_corner_y = quad_pos[quad][1] * px_conversion
@@ -924,7 +924,7 @@ class LPD_1MGeometry(DetectorGeometryBase):
             tiles = []
             modules.append(tiles)
 
-            for a in range(self.n_asics_per_module):
+            for a in range(cls.n_asics_per_module):
                 if a < 8:
                     up = -a
                     across = -1

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -295,16 +295,18 @@ class DetectorGeometryBase:
 
         if adu_per_ev is None:
             warnings.warn('adu_per_ev must be set; Setting to default value')
-            adu_per_ev_str = '; adu_per_eV = 0.0075'
+            adu_per_ev_str = '; adu_per_eV = SET ME'
+            # TODO: adu_per_ev should be fixed for each detector, we should 
+            #       find out the values and set them.
         else:
             adu_per_ev_str = 'adu_per_eV = {}'.format(adu_per_ev)
         if clen is None:
-            clen_str = '; clen = 0.119'
+            clen_str = '; clen = SET ME'
             warnings.warn('clen must be set; Setting to default value')
         else:
             clen_str = 'clen = {}'.format(clen)
         if photon_energy is None:
-            photon_energy_str = '; photon_energy = 9800'
+            photon_energy_str = '; photon_energy = SET ME'
             warnings.warn('photon_energy must be set, setting to default value')
         else:
             photon_energy_str = 'photon_energy = {}'.format(photon_energy)
@@ -1163,8 +1165,6 @@ class LPD_1MGeometry(DetectorGeometryBase):
 
     @classmethod
     def _tile_dims(cls, moduleno, tileno):
-        # Which part of the array is this tile?
-        module_offset = moduleno * 256
         if tileno < 8: # First half of module (0 <= t <=7)
             fs_dims = 0, 127
             tiles_up = 7 - tileno

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -331,7 +331,7 @@ class DetectorGeometryBase:
                                                               ss_dims,
                                                               fs_dims,
                                                               tile_dims))
-        pix_size = self.pixel_size * 1e6 # Convert pixels size to microns
+        resolution = 1.0 / self.pixel_size  # Pixels per metre
         paths = dict(data=data_path)
         if mask_path:
             paths['mask'] = mask_path
@@ -340,7 +340,7 @@ class DetectorGeometryBase:
             f.write(CRYSTFEL_HEADER_TEMPLATE.format(version=__version__,
                                                     paths=path_str,
                                                     frame_dim=frame_dim,
-                                                    pix_size=pix_size,
+                                                    resolution=resolution,
                                                     adu_per_ev=adu_per_ev_str,
                                                     clen=clen_str,
                                                     photon_energy=photon_energy_str))
@@ -898,7 +898,7 @@ CRYSTFEL_HEADER_TEMPLATE = """\
 
 {paths}
 {frame_dim}
-res = {pix_size} ;
+res = {resolution} ; pixels per metre
 
 ; Beam energy in eV
 {photon_energy}

--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -223,6 +223,28 @@ class DetectorGeometryBase:
                 tiles.append(GeometryFragment.from_panel_dict(d))
         return cls(modules, filename=filename)
 
+    def _get_rigid_groups(self, nquads=4):
+        """Create ridget stings for rigid groups definiton."""
+
+        quads = ','.join(['q{}'.format(q) for q in range(nquads)])
+        modules = ','.join(['p{}'.format(p) for p in range(self.n_modules)])
+
+        prod = product(range(self.n_modules), range(self.n_asics_per_module))
+        rigid_group = ['p{}a{}'.format(p, a) for (p, a) in prod]
+        rigid_string = '\n'
+
+        for nn, rigid_group_q in enumerate(np.array_split(rigid_group, nquads)):
+            rigid_string += 'rigid_group_q{} = {}\n'.format(nn, ','.join(rigid_group_q))
+        rigid_string += '\n'
+        for nn, rigid_group_p in enumerate(np.array_split(rigid_group, self.n_modules)):
+            rigid_string += 'rigid_group_p{} = {}\n'.format(nn, ','.join(rigid_group_p))
+
+        rigid_string += '\n'
+
+        rigid_string += 'rigid_group_collection_quadrants = {}\n'.format(quads)
+        rigid_string += 'rigid_group_collection_asics = {}\n\n'.format(modules)
+        return rigid_string
+
     def write_crystfel_geom(self, filename):
         """Write this geometry to a CrystFEL format (.geom) geometry file."""
         from . import __version__
@@ -235,6 +257,8 @@ class DetectorGeometryBase:
         with open(filename, 'w') as f:
             f.write(CRYSTFEL_HEADER_TEMPLATE.format(version=__version__,
                                                     pix_size=pix_size))
+            rigid_groups = self._get_rigid_groups()
+            f.write(rigid_groups)
             for chunk in panel_chunks:
                 f.write(chunk)
 
@@ -782,32 +806,6 @@ res = {pix_size} ;
 photon_energy = 10235 ;
 clen = 0.119  ; Camera length, aka detector distance
 adu_per_eV = 0.0075  ; no idea
-
-
-rigid_group_q0 = p0a0,p0a1,p0a2,p0a3,p0a4,p0a5,p0a6,p0a7,p1a0,p1a1,p1a2,p1a3,p1a4,p1a5,p1a6,p1a7,p2a0,p2a1,p2a2,p2a3,p2a4,p2a5,p2a6,p2a7,p3a0,p3a1,p3a2,p3a3,p3a4,p3a5,p3a6,p3a7
-rigid_group_q1 = p4a0,p4a1,p4a2,p4a3,p4a4,p4a5,p4a6,p4a7,p5a0,p5a1,p5a2,p5a3,p5a4,p5a5,p5a6,p5a7,p6a0,p6a1,p6a2,p6a3,p6a4,p6a5,p6a6,p6a7,p7a0,p7a1,p7a2,p7a3,p7a4,p7a5,p7a6,p7a7
-rigid_group_q2 = p8a0,p8a1,p8a2,p8a3,p8a4,p8a5,p8a6,p8a7,p9a0,p9a1,p9a2,p9a3,p9a4,p9a5,p9a6,p9a7,p10a0,p10a1,p10a2,p10a3,p10a4,p10a5,p10a6,p10a7,p11a0,p11a1,p11a2,p11a3,p11a4,p11a5,p11a6,p11a7
-rigid_group_q3 = p12a0,p12a1,p12a2,p12a3,p12a4,p12a5,p12a6,p12a7,p13a0,p13a1,p13a2,p13a3,p13a4,p13a5,p13a6,p13a7,p14a0,p14a1,p14a2,p14a3,p14a4,p14a5,p14a6,p14a7,p15a0,p15a1,p15a2,p15a3,p15a4,p15a5,p15a6,p15a7
-
-rigid_group_p0 = p0a0,p0a1,p0a2,p0a3,p0a4,p0a5,p0a6,p0a7
-rigid_group_p1 = p1a0,p1a1,p1a2,p1a3,p1a4,p1a5,p1a6,p1a7
-rigid_group_p2 = p2a0,p2a1,p2a2,p2a3,p2a4,p2a5,p2a6,p2a7
-rigid_group_p3 = p3a0,p3a1,p3a2,p3a3,p3a4,p3a5,p3a6,p3a7
-rigid_group_p4 = p4a0,p4a1,p4a2,p4a3,p4a4,p4a5,p4a6,p4a7
-rigid_group_p5 = p5a0,p5a1,p5a2,p5a3,p5a4,p5a5,p5a6,p5a7
-rigid_group_p6 = p6a0,p6a1,p6a2,p6a3,p6a4,p6a5,p6a6,p6a7
-rigid_group_p7 = p7a0,p7a1,p7a2,p7a3,p7a4,p7a5,p7a6,p7a7
-rigid_group_p8 = p8a0,p8a1,p8a2,p8a3,p8a4,p8a5,p8a6,p8a7
-rigid_group_p9 = p9a0,p9a1,p9a2,p9a3,p9a4,p9a5,p9a6,p9a7
-rigid_group_p10 = p10a0,p10a1,p10a2,p10a3,p10a4,p10a5,p10a6,p10a7
-rigid_group_p11 = p11a0,p11a1,p11a2,p11a3,p11a4,p11a5,p11a6,p11a7
-rigid_group_p12 = p12a0,p12a1,p12a2,p12a3,p12a4,p12a5,p12a6,p12a7
-rigid_group_p13 = p13a0,p13a1,p13a2,p13a3,p13a4,p13a5,p13a6,p13a7
-rigid_group_p14 = p14a0,p14a1,p14a2,p14a3,p14a4,p14a5,p14a6,p14a7
-rigid_group_p15 = p15a0,p15a1,p15a2,p15a3,p15a4,p15a5,p15a6,p15a7
-
-rigid_group_collection_quadrants = q0,q1,q2,q3
-rigid_group_collection_asics = p0,p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15
 
 """
 

--- a/karabo_data/tests/test_agipd_geometry.py
+++ b/karabo_data/tests/test_agipd_geometry.py
@@ -42,6 +42,7 @@ def test_write_read_crystfel_file(tmpdir):
     assert geom_dict['rigid_groups']['p0'] == quad_gr0[:8]
     assert geom_dict['rigid_groups']['p3'] == quad_gr0[-8:]
     assert geom_dict['rigid_groups']['q0'] == quad_gr0
+    assert geom_dict['panels']['p0a0']['res'] == 5000  # 5000 pixels/metre
 
 
 def test_inspect():

--- a/karabo_data/tests/test_agipd_geometry.py
+++ b/karabo_data/tests/test_agipd_geometry.py
@@ -1,3 +1,5 @@
+
+from cfelpyutils.crystfel_utils import load_crystfel_geometry
 from matplotlib.axes import Axes
 import numpy as np
 
@@ -22,22 +24,24 @@ def test_write_read_crystfel_file(tmpdir):
         quad_pos=[(-525, 625), (-550, -10), (520, -160), (542.5, 475)]
     )
     path = str(tmpdir / 'test.geom')
-    geom.write_crystfel_geom(path)
-
-    # We need to add some experiment details before cfelpyutils will read the
-    # file
-    with open(path, 'r') as f:
-        contents = f.read()
-    with open(path, 'w') as f:
-        f.write('clen = 0.119\n')
-        f.write('adu_per_eV = 0.0075\n')
-        f.write(contents)
+    geom.write_crystfel_geom(filename=path, photon_energy=9000,
+                             adu_per_ev=0.0075, clen=0.2)
 
     loaded = AGIPD_1MGeometry.from_crystfel_geom(path)
     np.testing.assert_allclose(
         loaded.modules[0][0].corner_pos, geom.modules[0][0].corner_pos
     )
     np.testing.assert_allclose(loaded.modules[0][0].fs_vec, geom.modules[0][0].fs_vec)
+
+    # Load the geometry file with cfelpyutils and test the ridget groups
+    geom_dict = load_crystfel_geometry(path)
+    quad_gr0 = ['p0a0', 'p0a1', 'p0a2', 'p0a3', 'p0a4', 'p0a5', 'p0a6', 'p0a7',
+               'p1a0', 'p1a1', 'p1a2', 'p1a3', 'p1a4', 'p1a5', 'p1a6', 'p1a7',
+               'p2a0', 'p2a1', 'p2a2', 'p2a3', 'p2a4', 'p2a5', 'p2a6', 'p2a7',
+               'p3a0', 'p3a1', 'p3a2', 'p3a3', 'p3a4', 'p3a5', 'p3a6', 'p3a7']
+    assert geom_dict['rigid_groups']['p0'] == quad_gr0[:8]
+    assert geom_dict['rigid_groups']['p3'] == quad_gr0[-8:]
+    assert geom_dict['rigid_groups']['q0'] == quad_gr0
 
 
 def test_inspect():

--- a/karabo_data/tests/test_lpd_geometry.py
+++ b/karabo_data/tests/test_lpd_geometry.py
@@ -1,3 +1,5 @@
+import os
+from cfelpyutils.crystfel_utils import load_crystfel_geometry
 import h5py
 from matplotlib.axes import Axes
 import numpy as np
@@ -7,6 +9,42 @@ from karabo_data.geometry2 import LPD_1MGeometry, invert_xfel_lpd_geom
 
 tests_dir = dirname(abspath(__file__))
 
+
+def test_write_read_crystfel_file(tmpdir):
+    geom = LPD_1MGeometry.from_quad_positions(
+        [(11.4, 299), (-11.5, 8), (254.5, -16), (278.5, 275)]
+    )
+    path = str(tmpdir / 'test.geom')
+    geom.write_crystfel_geom(filename=path)
+
+    with open(path, 'r') as f:
+        contents = f.read()
+    with open(path, 'w') as f:
+        f.write('clen = 0.119\n')
+        f.write('adu_per_eV = 0.0075\n')
+
+        f.write(contents)
+    # Load the geometry file with cfelpyutils and test the ridget groups
+    loaded = LPD_1MGeometry.from_crystfel_geom(path)
+    np.testing.assert_allclose(
+        loaded.modules[0][0].corner_pos, geom.modules[0][0].corner_pos
+    )
+    np.testing.assert_allclose(loaded.modules[0][0].fs_vec, geom.modules[0][0].fs_vec)
+
+
+    geom_dict = load_crystfel_geometry(path)
+    quad_gr0 = ['p0a0', 'p0a1', 'p0a2', 'p0a3', 'p0a4', 'p0a5', 'p0a6', 'p0a7',
+                'p0a8', 'p0a9', 'p0a10','p0a11', 'p0a12', 'p0a13', 'p0a14',
+                'p0a15', 'p1a0', 'p1a1','p1a2', 'p1a3','p1a4','p1a5','p1a6',
+                'p1a7', 'p1a8', 'p1a9', 'p1a10', 'p1a11', 'p1a12', 'p1a13',
+                'p1a14', 'p1a15', 'p2a0', 'p2a1', 'p2a2', 'p2a3', 'p2a4', 'p2a5',
+                'p2a6', 'p2a7', 'p2a8', 'p2a9', 'p2a10', 'p2a11', 'p2a12', 'p2a13',
+                'p2a14','p2a15', 'p3a0', 'p3a1','p3a2', 'p3a3', 'p3a4', 'p3a5',
+                'p3a6', 'p3a7', 'p3a8','p3a9', 'p3a10', 'p3a11', 'p3a12', 'p3a13',
+                'p3a14', 'p3a15']
+    assert geom_dict['rigid_groups']['p0'] == quad_gr0[:16]
+    assert geom_dict['rigid_groups']['p3'] == quad_gr0[-16:]
+    assert geom_dict['rigid_groups']['q0'] == quad_gr0
 
 def test_inspect():
     geom = LPD_1MGeometry.from_quad_positions(


### PR DESCRIPTION
This PR aims at loading/writing CFEL geometry file format for all detectors.

Background is that CFEL people planning an experiment at FXE with the LPD. Hence they want to use crystfel with LPD data.