### PR TITLE
Better error message for missing train ID

### DIFF
--- a/karabo_data/exceptions.py
+++ b/karabo_data/exceptions.py
@@ -19,3 +19,11 @@ class PropertyNameError(KeyError):
 
     def __str__(self):
         return "No property {!r} for source {!r}".format(self.prop, self.source)
+
+
+class TrainIDError(KeyError):
+    def __init__(self, train_id):
+        self.train_id = train_id
+
+    def __str__(self):
+        return "Train ID {!r} not found in this data".format(self.train_id)

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -25,7 +25,7 @@ import sys
 from warnings import warn
 import xarray
 
-from .exceptions import SourceNameError, PropertyNameError
+from .exceptions import SourceNameError, PropertyNameError, TrainIDError
 from .read_machinery import (
     DETECTOR_SOURCE_RE,
     DataChunk,
@@ -375,7 +375,7 @@ class DataCollection:
             if `train_id` is not found in the run.
         """
         if train_id not in self.train_ids:
-            raise KeyError(train_id)
+            raise TrainIDError(train_id)
 
         if devices is not None:
             return self.select(devices).train_from_id(train_id)

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -17,7 +17,6 @@ from glob import glob
 import h5py
 import logging
 import numpy as np
-import os
 import os.path as osp
 import pandas as pd
 import re


### PR DESCRIPTION
From https://in.xfel.eu/redmine/issues/42350

Before:

```
KeyError: 131029985
```

After:

```
TrainIDError: Train ID 131029985 not found in this data
```