### PR TITLE
Start writing release notes for 0.5

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,37 @@
 Release Notes
 =============
 
+0.5
+---
+
+Data access
+~~~~~~~~~~~
+
+- Create a virtual dataset for any single dataset with
+  :meth:`~.get_virtual_dataset` (:ghpull:`162`).
+  See :doc:`parallel_example` for how this can be useful.
+- Write a file with virtual datasets for all selected data with
+  :meth:`~.write_virtual` (:ghpull:`132`).
+- Data from the supported multi-module detectors (AGIPD, LPD & DSSC) can be
+  exposed in CXI format using a virtual dataset - see
+  :meth:`~.write_virtual_cxi` (:ghpull:`150`, :ghpull:`166`, :ghpull:`173`).
+- New class :class:`~.DSSC` for accessing DSSC data (:ghpull:`171`).
+- New function :func:`~.open_run` to access a run by proposal and run number
+  rather than path (:ghpull:`147`).
+- :func:`~.stack_detector_data` now allows input data where some sources don't
+  have the specified key (:ghpull:`141`).
+
+Detector geometry
+~~~~~~~~~~~~~~~~~
+
+- New class :class:`~.DSSC_Geometry` for handling DSSC detector geometry (:ghpull:`155`).
+- :class:`~.LPD_1MGeometry` can now read and write CrystFEL format
+  geometry files, and produce PyFAI distortion arrays (:ghpull:`168`, :ghpull:`129`).
+- :meth:`~.AGIPD_1MGeometry.write_crystfel_geom` (for AGIPD and LPD geometry)
+  now accepts various optional parameters for other details to be written into
+  the geometry file, such as the detector distance (``clen``) and the photon
+  energy (:ghpull:`168`).
+
 0.4
 ---
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Data access
   rather than path (:ghpull:`147`).
 - :func:`~.stack_detector_data` now allows input data where some sources don't
   have the specified key (:ghpull:`141`).
+- Files in the new ``1.0`` data format can now be opened (:ghpull:`182`).
 
 Detector geometry
 ~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,11 @@ Detector geometry
   now accepts various optional parameters for other details to be written into
   the geometry file, such as the detector distance (``clen``) and the photon
   energy (:ghpull:`168`).
+- New method :meth:`~.AGIPD_1MGeometry.get_pixel_positions` to get the physical
+  position of every pixel in a detector, for all of AGIPD, LPD and DSSC
+  (:ghpull:`142`).
+- New method :meth:`~.AGIPD_1MGeometry.data_coords_to_positions` to convert data
+  array coordinates to physical positions, for AGIPD and LPD (:ghpull:`142`).
 
 0.4
 ---

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,8 @@ Release Notes
 Data access
 ~~~~~~~~~~~
 
+- New method :meth:`~.get_data_counts` to find how many data points were
+  recorded in each train for a given source and key.
 - Create a virtual dataset for any single dataset with
   :meth:`~.get_virtual_dataset` (:ghpull:`162`).
   See :doc:`parallel_example` for how this can be useful.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,11 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
     'nbsphinx',
+    'sphinxcontrib_github_alt',
 ]
+
+# For :ghissue: and :ghpull: links.
+github_project_url = "https://github.com/European-XFEL/karabo_data/"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(name="karabo_data",
               'sphinx',
               'nbsphinx',
               'ipython',  # For nbsphinx syntax highlighting
+              'sphinxcontrib_github_alt',
           ],
           'test': [
               'pytest',


### PR DESCRIPTION
I've also enabled [sphinxcontrib-github-alt](https://pypi.org/project/sphinxcontrib_github_alt/). This is an extension we use in Jupyter to link to Github issues and pull requests, and I like to write release notes with links to the relevant PRs.