### PR TITLE
Restore deprecated DSSC_Geometry name for now

### DIFF
--- a/karabo_data/geometry2.py
+++ b/karabo_data/geometry2.py
@@ -1441,3 +1441,12 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         distortion[..., 1:] -= min_yx
 
         return distortion
+
+
+class DSSC_Geometry(DSSC_1MGeometry):
+    """DEPRECATED: Use DSSC_1MGeometry instead"""
+    def __init__(self, modules, filename='No file'):
+        super().__init__(modules, filename)
+        warnings.warn(
+            "DSSC_Geometry has been renamed to DSSC_1MGeometry.", stacklevel=2
+        )


### PR DESCRIPTION
I noticed there's at least one example already circulating with the old name in use. It's easy enough to leave it there as a compatibility alias for now, and print a warning when it's used.

cc @tmichela 