### PR TITLE
Allow creating and reusing an output array for assembling detector images

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -50,6 +50,8 @@ but this geometry code works with a position for each tile.
 
    .. automethod:: position_modules_fast
 
+   .. automethod:: output_array_for_position_fast
+
    .. automethod:: position_modules_interpolate
 
    .. automethod:: inspect
@@ -87,6 +89,8 @@ which this geometry code can position independently.
 
    .. automethod:: position_modules_fast
 
+   .. automethod:: output_array_for_position_fast
+
    .. automethod:: inspect
 
    .. automethod:: data_coords_to_positions
@@ -123,5 +127,7 @@ approximately half a pixel width from their true position.
    .. automethod:: plot_data_fast
 
    .. automethod:: position_modules_fast
+
+   .. automethod:: output_array_for_position_fast
 
    .. automethod:: inspect


### PR DESCRIPTION
As described in #165, this offers something like a 40% speedup if you're repeatedly assembling a train of images from the same detector with the same geometry. I've tested it with a train of 176 AGIPD images, and I think I'm seeing that kind of improvement, although the actual timings are rather variable.

@ebadkamil @zhujun98 - I think this is something karaboFAI could make use of. Whether or not you intend to, it would be good if you could review this code, as you're familiar with using it for this kind of scenario.