### PR TITLE
Assume .h5 files are HDF5 when opening a run

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1171,7 +1171,7 @@ def RunDirectory(path):
     path: str
         Path to the run directory containing HDF5 files.
     """
-    files = list(filter(h5py.is_hdf5, glob(osp.join(path, '*.h5'))))
+    files = glob(osp.join(path, '*.h5'))
     if not files:
         raise Exception("No HDF5 files found in {}".format(path))
     return DataCollection.from_paths(files)


### PR DESCRIPTION
We already catch errors when opening the files, so we'll catch if we try to open a file that's not valid HDF5.

This speeds up opening a run by about 5% in my tests. That's a small gain, but it's low-hanging fruit - neither us nor the users need to do anything clever to use it. I'm thinking about how to get bigger speed improvements.