### PR TITLE
Support 2D array layouts for CrystFEL format geometry.

### DIFF
--- a/karabo_data/geometry2/__init__.py
+++ b/karabo_data/geometry2/__init__.py
@@ -248,7 +248,7 @@ class DetectorGeometryBase:
             should be added by their index, e.g.
             ('frame', 'modno', 0, 'ss', 'fs') for raw data.
             Default: ``('frame', 'modno', 'ss', 'fs')``.
-            Note: the dimensions must contain frame, modno, ss, fs.
+            Note: the dimensions must contain frame, ss, fs.
         adu_per_ev : float
             ADU (analog digital units) per electron volt for the considered
             detector.

--- a/karabo_data/geometry2/__init__.py
+++ b/karabo_data/geometry2/__init__.py
@@ -289,7 +289,7 @@ class DetectorGeometryBase:
         photon_energy : float
             Beam wave length in eV
         """
-        from . import __version__
+        from .. import __version__
 
         if adu_per_ev is None:
             adu_per_ev_str = '; adu_per_eV = SET ME'

--- a/karabo_data/geometry2/__init__.py
+++ b/karabo_data/geometry2/__init__.py
@@ -7,16 +7,9 @@ import numpy as np
 from scipy.ndimage import affine_transform
 import warnings
 
+from .crystfel_fmt import write_crystfel_geom
+
 __all__ = ['AGIPD_1MGeometry', 'LPD_1MGeometry']
-
-
-def _crystfel_format_vec(vec):
-    """Convert an array of 3 numbers to CrystFEL format like "+1.0x -0.1y"
-    """
-    s = '{:+}x {:+}y'.format(*vec[:2])
-    if vec[2] != 0:
-        s += ' {:+}z'.format(vec[2])
-    return s
 
 
 class GeometryFragment:
@@ -60,31 +53,6 @@ class GeometryFragment:
             self.corner_pos
             + (0.5 * self.ss_vec * self.ss_pixels)
             + (0.5 * self.fs_vec * self.fs_pixels)
-        )
-
-    def to_crystfel_geom(self, p, a, ss_slice, fs_slice, dims):
-        tile_name = 'p{}a{}'.format(p, a)
-        c = self.corner_pos
-        dim_list = []
-        for num, value in dims.items():
-            if value == 'modno':
-                key = p
-            else:
-                key = value
-            dim_list.append('{}/dim{} = {}'.format(tile_name, num, key))
-
-        return CRYSTFEL_PANEL_TEMPLATE.format(
-            dims='\n'.join(dim_list),
-            name=tile_name,
-            min_ss=ss_slice.start,
-            max_ss=ss_slice.stop - 1,
-            min_fs=fs_slice.start,
-            max_fs=fs_slice.stop - 1,
-            ss_vec=_crystfel_format_vec(self.ss_vec),
-            fs_vec=_crystfel_format_vec(self.fs_vec),
-            corner_x=c[0],
-            corner_y=c[1],
-            coffset=c[2],
         )
 
     def snap(self, px_shape=np.array([1., 1.])):
@@ -289,61 +257,10 @@ class DetectorGeometryBase:
         photon_energy : float
             Beam wave length in eV
         """
-        from .. import __version__
-
-        if adu_per_ev is None:
-            adu_per_ev_str = '; adu_per_eV = SET ME'
-            # TODO: adu_per_ev should be fixed for each detector, we should
-            #       find out the values and set them.
-        else:
-            adu_per_ev_str = 'adu_per_eV = {}'.format(adu_per_ev)
-
-        if clen is None:
-            clen_str = '; clen = SET ME'
-        else:
-            clen_str = 'clen = {}'.format(clen)
-
-        if photon_energy is None:
-            photon_energy_str = '; photon_energy = SET ME'
-        else:
-            photon_energy_str = 'photon_energy = {}'.format(photon_energy)
-
-        # Get the frame dimension
-        tile_dims = {}
-
-        frame_dim = None
-        for nn, dim_name in enumerate(dims):
-            if dim_name == 'frame':
-                frame_dim = 'dim{} = %'.format(nn)
-            else:
-                tile_dims[nn] = dim_name
-        if frame_dim is None:
-            raise ValueError('No frame dimension given')
-
-        panel_chunks = []
-        for p, module in enumerate(self.modules):
-            for a, fragment in enumerate(module):
-                ss_slice, fs_slice = self._tile_slice(a)
-                panel_chunks.append(fragment.to_crystfel_geom(
-                    p, a, ss_slice, fs_slice, tile_dims
-                ))
-        resolution = 1.0 / self.pixel_size  # Pixels per metre
-        paths = dict(data=data_path)
-        if mask_path:
-            paths['mask'] = mask_path
-        path_str = '\n'.join('{} = {} ;'.format(i, j) for i, j in paths.items())
-        with open(filename, 'w') as f:
-            f.write(CRYSTFEL_HEADER_TEMPLATE.format(version=__version__,
-                                                    paths=path_str,
-                                                    frame_dim=frame_dim,
-                                                    resolution=resolution,
-                                                    adu_per_ev=adu_per_ev_str,
-                                                    clen=clen_str,
-                                                    photon_energy=photon_energy_str))
-            rigid_groups = self._get_rigid_groups()
-            f.write(rigid_groups)
-            for chunk in panel_chunks:
-                f.write(chunk)
+        write_crystfel_geom(
+            self, filename, data_path=data_path, mask_path=mask_path, dims=dims,
+            adu_per_ev=adu_per_ev, clen=clen, photon_energy=photon_energy,
+        )
 
         if self.filename == 'No file':
             self.filename = filename
@@ -1049,45 +966,6 @@ class SnappedGeometry:
         ax.hlines(0, -cross_size, +cross_size, colors='w', linewidths=1)
         ax.vlines(0, -cross_size, +cross_size, colors='w', linewidths=1)
         return ax
-
-
-CRYSTFEL_HEADER_TEMPLATE = """\
-; AGIPD-1M geometry file written by karabo_data {version}
-; You may need to edit this file to add:
-; - data and mask locations in the file
-; - mask_good & mask_bad values to interpret the mask
-; - adu_per_eV & photon_energy
-; - clen (detector distance)
-;
-; See: http://www.desy.de/~twhite/crystfel/manual-crystfel_geometry.html
-
-{paths}
-{frame_dim}
-res = {resolution} ; pixels per metre
-
-; Beam energy in eV
-{photon_energy}
-
-; Camera length, aka detector distance
-{clen}
-
-; Analogue Digital Units per eV
-{adu_per_ev}
-"""
-
-
-CRYSTFEL_PANEL_TEMPLATE = """
-{dims}
-{name}/min_fs = {min_fs}
-{name}/min_ss = {min_ss}
-{name}/max_fs = {max_fs}
-{name}/max_ss = {max_ss}
-{name}/fs = {fs_vec}
-{name}/ss = {ss_vec}
-{name}/corner_x = {corner_x}
-{name}/corner_y = {corner_y}
-{name}/coffset = {coffset}
-"""
 
 
 class LPD_1MGeometry(DetectorGeometryBase):

--- a/karabo_data/geometry2/crystfel_fmt.py
+++ b/karabo_data/geometry2/crystfel_fmt.py
@@ -1,0 +1,142 @@
+"""Read and write geometry in CrystFEL format.
+"""
+
+HEADER_TEMPLATE = """\
+; AGIPD-1M geometry file written by karabo_data {version}
+; You may need to edit this file to add:
+; - data and mask locations in the file
+; - mask_good & mask_bad values to interpret the mask
+; - adu_per_eV & photon_energy
+; - clen (detector distance)
+;
+; See: http://www.desy.de/~twhite/crystfel/manual-crystfel_geometry.html
+
+{paths}
+{frame_dim}
+res = {resolution} ; pixels per metre
+
+; Beam energy in eV
+{photon_energy}
+
+; Camera length, aka detector distance
+{clen}
+
+; Analogue Digital Units per eV
+{adu_per_ev}
+"""
+
+
+PANEL_TEMPLATE = """
+{dims}
+{name}/min_fs = {min_fs}
+{name}/min_ss = {min_ss}
+{name}/max_fs = {max_fs}
+{name}/max_ss = {max_ss}
+{name}/fs = {fs_vec}
+{name}/ss = {ss_vec}
+{name}/corner_x = {corner_x}
+{name}/corner_y = {corner_y}
+{name}/coffset = {coffset}
+"""
+
+
+def _crystfel_format_vec(vec):
+    """Convert an array of 3 numbers to CrystFEL format like "+1.0x -0.1y"
+    """
+    s = '{:+}x {:+}y'.format(*vec[:2])
+    if vec[2] != 0:
+        s += ' {:+}z'.format(vec[2])
+    return s
+
+
+def frag_to_crystfel(fragment, p, a, ss_slice, fs_slice, dims):
+    tile_name = 'p{}a{}'.format(p, a)
+    c = fragment.corner_pos
+    dim_list = []
+    for num, value in dims.items():
+        if value == 'modno':
+            key = p
+        else:
+            key = value
+        dim_list.append('{}/dim{} = {}'.format(tile_name, num, key))
+
+    return PANEL_TEMPLATE.format(
+        dims='\n'.join(dim_list),
+        name=tile_name,
+        min_ss=ss_slice.start,
+        max_ss=ss_slice.stop - 1,
+        min_fs=fs_slice.start,
+        max_fs=fs_slice.stop - 1,
+        ss_vec=_crystfel_format_vec(fragment.ss_vec),
+        fs_vec=_crystfel_format_vec(fragment.fs_vec),
+        corner_x=c[0],
+        corner_y=c[1],
+        coffset=c[2],
+    )
+
+def write_crystfel_geom(self, filename, *,
+                        data_path='/entry_1/instrument_1/detector_1/data',
+                        mask_path=None, dims=('frame', 'modno', 'ss', 'fs'),
+                        adu_per_ev=None, clen=None, photon_energy=None):
+    """Write this geometry to a CrystFEL format (.geom) geometry file.
+    """
+    from .. import __version__
+
+    if adu_per_ev is None:
+        adu_per_ev_str = '; adu_per_eV = SET ME'
+        # TODO: adu_per_ev should be fixed for each detector, we should
+        #       find out the values and set them.
+    else:
+        adu_per_ev_str = 'adu_per_eV = {}'.format(adu_per_ev)
+
+    if clen is None:
+        clen_str = '; clen = SET ME'
+    else:
+        clen_str = 'clen = {}'.format(clen)
+
+    if photon_energy is None:
+        photon_energy_str = '; photon_energy = SET ME'
+    else:
+        photon_energy_str = 'photon_energy = {}'.format(photon_energy)
+
+    # Get the frame dimension
+    tile_dims = {}
+
+    frame_dim = None
+    for nn, dim_name in enumerate(dims):
+        if dim_name == 'frame':
+            frame_dim = 'dim{} = %'.format(nn)
+        else:
+            tile_dims[nn] = dim_name
+    if frame_dim is None:
+        raise ValueError('No frame dimension given')
+
+    panel_chunks = []
+    for p, module in enumerate(self.modules):
+        for a, fragment in enumerate(module):
+            ss_slice, fs_slice = self._tile_slice(a)
+            panel_chunks.append(frag_to_crystfel(
+                fragment, p, a, ss_slice, fs_slice, tile_dims
+            ))
+
+    resolution = 1.0 / self.pixel_size  # Pixels per metre
+
+    paths = dict(data=data_path)
+    if mask_path:
+        paths['mask'] = mask_path
+    path_str = '\n'.join('{} = {} ;'.format(i, j) for i, j in paths.items())
+
+    with open(filename, 'w') as f:
+        f.write(HEADER_TEMPLATE.format(
+            version=__version__,
+            paths=path_str,
+            frame_dim=frame_dim,
+            resolution=resolution,
+            adu_per_ev=adu_per_ev_str,
+            clen=clen_str,
+            photon_energy=photon_energy_str
+        ))
+        rigid_groups = self._get_rigid_groups()
+        f.write(rigid_groups)
+        for chunk in panel_chunks:
+            f.write(chunk)

--- a/karabo_data/geometry2/crystfel_fmt.py
+++ b/karabo_data/geometry2/crystfel_fmt.py
@@ -1,4 +1,4 @@
-"""Read and write geometry in CrystFEL format.
+"""Write geometry in CrystFEL format.
 """
 
 HEADER_TEMPLATE = """\
@@ -115,6 +115,15 @@ def write_crystfel_geom(self, filename, *,
     for p, module in enumerate(self.modules):
         for a, fragment in enumerate(module):
             ss_slice, fs_slice = self._tile_slice(a)
+            if 'modno' not in dims:
+                # If we don't have a modno dimension, assume modules are
+                # concatenated along the slow-scan dim, e.g. AGIPD (8192, 128)
+                module_offset = p * self.expected_data_shape[1]
+                ss_slice = slice(
+                    ss_slice.start + module_offset,
+                    ss_slice.stop + module_offset
+                )
+
             panel_chunks.append(frag_to_crystfel(
                 fragment, p, a, ss_slice, fs_slice, tile_dims
             ))

--- a/karabo_data/tests/test_agipd_geometry.py
+++ b/karabo_data/tests/test_agipd_geometry.py
@@ -68,6 +68,7 @@ def test_write_read_crystfel_file_2d(tmpdir):
     geom_dict = load_crystfel_geometry(path)
 
     p3a7 = geom_dict['panels']['p3a7']
+    assert p3a7['dim_structure'] == ['%', 'ss', 'fs']
     assert p3a7['min_ss'] == (3 * 512) + 448
     assert p3a7['max_ss'] == (3 * 512) + 511
     assert p3a7['min_fs'] == 0

--- a/karabo_data/tests/test_agipd_geometry.py
+++ b/karabo_data/tests/test_agipd_geometry.py
@@ -1,5 +1,6 @@
 
 from cfelpyutils.crystfel_utils import load_crystfel_geometry
+from itertools import product
 from matplotlib.axes import Axes
 import numpy as np
 
@@ -35,10 +36,9 @@ def test_write_read_crystfel_file(tmpdir):
 
     # Load the geometry file with cfelpyutils and test the rigid groups
     geom_dict = load_crystfel_geometry(path)
-    quad_gr0 = ['p0a0', 'p0a1', 'p0a2', 'p0a3', 'p0a4', 'p0a5', 'p0a6', 'p0a7',
-               'p1a0', 'p1a1', 'p1a2', 'p1a3', 'p1a4', 'p1a5', 'p1a6', 'p1a7',
-               'p2a0', 'p2a1', 'p2a2', 'p2a3', 'p2a4', 'p2a5', 'p2a6', 'p2a7',
-               'p3a0', 'p3a1', 'p3a2', 'p3a3', 'p3a4', 'p3a5', 'p3a6', 'p3a7']
+    quad_gr0 = [  # 1st quadrant: p0a0 ... p3a7
+        'p{}a{}'.format(p, a) for p, a in product(range(4), range(8))
+    ]
     assert geom_dict['rigid_groups']['p0'] == quad_gr0[:8]
     assert geom_dict['rigid_groups']['p3'] == quad_gr0[-8:]
     assert geom_dict['rigid_groups']['q0'] == quad_gr0

--- a/karabo_data/tests/test_agipd_geometry.py
+++ b/karabo_data/tests/test_agipd_geometry.py
@@ -33,7 +33,7 @@ def test_write_read_crystfel_file(tmpdir):
     )
     np.testing.assert_allclose(loaded.modules[0][0].fs_vec, geom.modules[0][0].fs_vec)
 
-    # Load the geometry file with cfelpyutils and test the ridget groups
+    # Load the geometry file with cfelpyutils and test the rigid groups
     geom_dict = load_crystfel_geometry(path)
     quad_gr0 = ['p0a0', 'p0a1', 'p0a2', 'p0a3', 'p0a4', 'p0a5', 'p0a6', 'p0a7',
                'p1a0', 'p1a1', 'p1a2', 'p1a3', 'p1a4', 'p1a5', 'p1a6', 'p1a7',
@@ -46,6 +46,30 @@ def test_write_read_crystfel_file(tmpdir):
     p3a7 = geom_dict['panels']['p3a7']
     assert p3a7['min_ss'] == 448
     assert p3a7['max_ss'] == 511
+    assert p3a7['min_fs'] == 0
+    assert p3a7['max_fs'] == 127
+
+
+def test_write_read_crystfel_file_2d(tmpdir):
+    geom = AGIPD_1MGeometry.from_quad_positions(
+        quad_pos=[(-525, 625), (-550, -10), (520, -160), (542.5, 475)]
+    )
+    path = str(tmpdir / 'test.geom')
+    geom.write_crystfel_geom(filename=path, dims=('frame', 'ss', 'fs'),
+                             adu_per_ev=0.0075, clen=0.2)
+
+    loaded = AGIPD_1MGeometry.from_crystfel_geom(path)
+    np.testing.assert_allclose(
+        loaded.modules[0][0].corner_pos, geom.modules[0][0].corner_pos
+    )
+    np.testing.assert_allclose(loaded.modules[0][0].fs_vec, geom.modules[0][0].fs_vec)
+
+    # Load the geometry file with cfelpyutils and check some values
+    geom_dict = load_crystfel_geometry(path)
+
+    p3a7 = geom_dict['panels']['p3a7']
+    assert p3a7['min_ss'] == (3 * 512) + 448
+    assert p3a7['max_ss'] == (3 * 512) + 511
     assert p3a7['min_fs'] == 0
     assert p3a7['max_fs'] == 127
 


### PR DESCRIPTION
Fixes #190. This was easier than I expected, thanks to @antarcticrainforest's work to describe the array dimensions for `write_crystfel_geom`. To use it for a 2D array, pass:

```python
geom.write_crystfel_geom(..., dims=('frame', 'ss', 'fs')
```

The default dims has an extra entry `'modno'`. The absence of this causes it to spread modules out along the slow-scan dimension instead.

I've also moved the CrystFEL writing code to a separate module so it's easier to see. To review the real functional changes here, ignore the first two commits.