### PR TITLE
Add dtype for output array creation

### DIFF
--- a/karabo_data/geometry2/__init__.py
+++ b/karabo_data/geometry2/__init__.py
@@ -286,7 +286,7 @@ class DetectorGeometryBase:
         """
         raise NotImplementedError
 
-    def output_array_for_position_fast(self, extra_shape=()):
+    def output_array_for_position_fast(self, extra_shape=(), dtype=np.float32):
         """Make an empty output array to use with position_modules_fast
 
         You can speed up assembling images by reusing the same output array:
@@ -301,8 +301,10 @@ class DetectorGeometryBase:
           By default, a 2D output array is generated, to assemble a single
           detector image. If you are assembling multiple pulses at once, pass
           ``extra_shape=(nframes,)`` to get a 3D output array.
+        dtype : optional (Default: np.float32)
         """
-        return self._snapped().make_output_array(extra_shape=extra_shape)
+        return self._snapped().make_output_array(extra_shape=extra_shape,
+                                                 dtype=dtype)
 
     def position_modules_fast(self, data, out=None):
         """Assemble data from this detector according to where the pixels are.


### PR DESCRIPTION
Want to use `output_array_for_position_fast` with specific dtype which may or maynot be `np.float32` and may also change on the fly during online analysis in karaboFAI. It will be good to have dtype for this function rather than using `_snapped().make_output_array` for external tools. Or may be there is another better way.

@takluyver 