### PR TITLE
Only include relevant files from .select() and .deselect()

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -810,7 +810,7 @@ class DataCollection:
         files = [f for f in self.files
                  if f.all_sources.intersection(selection.keys())]
 
-        return DataCollection(self.files, selection=selection, train_ids=self.train_ids)
+        return DataCollection(files, selection=selection, train_ids=self.train_ids)
 
     def select_trains(self, train_range):
         """Select a subset of trains from this data.

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -133,6 +133,10 @@ class FileAccess:
     def __repr__(self):
         return "{}({})".format(type(self).__name__, repr(self.file))
 
+    @property
+    def all_sources(self):
+        return self.control_sources | self.instrument_sources
+
     def get_index(self, source, group):
         """Get first index & count for a source and for a specific train ID.
 
@@ -769,7 +773,10 @@ class DataCollection:
             seln_or_source_glob = [(seln_or_source_glob, key_glob)]
         selection = self._expand_selection(seln_or_source_glob)
 
-        return DataCollection(self.files, selection=selection, train_ids=self.train_ids)
+        files = [f for f in self.files
+                 if f.all_sources.intersection(selection.keys())]
+
+        return DataCollection(files, selection=selection, train_ids=self.train_ids)
 
     def deselect(self, seln_or_source_glob, key_glob='*'):
         """Select everything except the specified sources and keys.
@@ -799,6 +806,9 @@ class DataCollection:
                 keys = self.keys_for_source(source)
 
             selection[source] = keys - desel_keys
+
+        files = [f for f in self.files
+                 if f.all_sources.intersection(selection.keys())]
 
         return DataCollection(self.files, selection=selection, train_ids=self.train_ids)
 

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -501,6 +501,14 @@ def test_union(mock_fxe_raw_run):
     assert joined.train_ids == list(range(10000, 10010)) + list(range(10200, 10220))
 
 
+def test_union_raw_proc(mock_spb_raw_run, mock_spb_proc_run):
+    raw_run = RunDirectory(mock_spb_raw_run)
+    proc_run = RunDirectory(mock_spb_proc_run)
+    run = raw_run.deselect('*AGIPD1M*').union(proc_run)
+
+    assert run.all_sources == (raw_run.all_sources | proc_run.all_sources)
+
+
 def test_read_skip_invalid(mock_lpd_data, empty_h5_file, capsys):
     d = DataCollection.from_paths([mock_lpd_data, empty_h5_file])
     assert d.instrument_sources == {'FXE_DET_LPD1M-1/DET/0CH0:xtdf'}


### PR DESCRIPTION
This partly addresses #131: it should make it possible to combine proc detector data with raw data, by deselecting the detector sources in the raw data.