### PR TITLE
Caching file contents for runs

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -1,7 +1,7 @@
 Performance notes
 =================
 
-These are some notes on how to make load and process data efficiently.
+These are some notes on how to load and process data efficiently.
 
 Load data into memory
 ---------------------

--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -203,3 +203,41 @@ Here are some problems we've seen, and possible solutions or workarounds:
 If you're having problems with karabo_data, you can also try searching
 `previously reported issues <https://github.com/European-XFEL/karabo_data/issues?q=is%3Aissue>`_
 to see if anyone has encountered similar symptoms.
+
+Cached run data maps
+--------------------
+
+When you open a run in karabo_data, it needs to know what data is in each file.
+Each file has metadata describing its contents, but reading this from every file
+is slow, especially on GPFS. karabo_data therefore tries to cache this
+information the first time a run is opened, and reuse it when opening that run
+again.
+
+This should happen automatically, without the user needing to know about it.
+You only need these details if you think caching may be causing problems.
+
+- Caching is triggered when you use :func:`RunDirectory` or :func:`open_run`.
+- There are two possible locations for the cached data map:
+
+  - In the run directory: ``(run dir)/karabo_data_map.json``.
+  - In the proposal scratch directory:
+    ``(proposal dir)/scratch/.karabo_data_maps/raw_r0032.json``.
+    This will normally be the one used on Maxwell, as users can't write to the
+    run directory.
+
+- The format is a JSON array, with an object for each file in the run.
+
+  - This holds the list of train IDs in the file, and the lists of control and
+    instrument sources.
+  - It also stores the file size and last modified time of each data file, to
+    check if the file has changed since the cache was created. If either of
+    these attributes doesn't match, karabo_data ignores the cached information
+    and reads the metadata from the HDF5 file.
+
+- If any file in the run wasn't listed in the data map, or its entry was
+  outdated, a new data map is written automatically. It tries the same two
+  locations described above, but it will continue without error if it can't
+  write to either.
+
+JSON was chosen as it can be easily inspected manually, and it's reasonably
+efficient to load the entire file.

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -79,9 +79,9 @@ class FileAccess:
         self.filename = filename
 
         if _cache_info:
-            self.train_ids = np.array(_cache_info['train_ids'], dtype=np.uint64)
-            self.control_sources = frozenset(_cache_info['control_sources'])
-            self.instrument_sources = frozenset(_cache_info['instrument_sources'])
+            self.train_ids = _cache_info['train_ids']
+            self.control_sources = _cache_info['control_sources']
+            self.instrument_sources = _cache_info['instrument_sources']
         else:
             tid_data = self.file['INDEX/trainId'][:]
             self.train_ids = tid_data[tid_data != 0]

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1335,7 +1335,7 @@ def RunDirectory(path, include='*'):
     """
     files = [f for f in os.listdir(path) if f.endswith('.h5')]
     files = [osp.join(path, f) for f in fnmatch.filter(files, include)]
-    if not files:s
+    if not files:
         raise Exception("No HDF5 files found in {} with glob pattern {}".format(path, include))
 
     files_map = RunFilesMap(path)

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -22,6 +22,7 @@ import os.path as osp
 import re
 import sys
 import tempfile
+import time
 
 from .exceptions import SourceNameError, PropertyNameError, TrainIDError
 from .read_machinery import (
@@ -1249,7 +1250,10 @@ def RunDirectory(path):
         raise Exception("No HDF5 files found in {}".format(path))
 
     files_map = RunFilesMap(path)
+    t0 = time.monotonic()
     d = DataCollection.from_paths(files, files_map)
+    log.debug("Opened run with %d files in %.2g s",
+              len(d.files), time.monotonic() - t0)
     files_map.save(d.files)
 
     return d

--- a/karabo_data/run_files_map.py
+++ b/karabo_data/run_files_map.py
@@ -16,7 +16,7 @@ class RunFilesMap:
     can be stored in:
 
     - (run dir)/karabo_data_map.json
-    - (proposal dir)/scratch/karabo_data_maps/raw_r0032.json
+    - (proposal dir)/scratch/.karabo_data_maps/raw_r0032.json
     """
     cache_file = None
 
@@ -32,7 +32,7 @@ class RunFilesMap:
             prop_dir, raw_proc, run_nr = m.groups()
             fname = '%s_%s.json' % (raw_proc, run_nr)
             self.candidate_paths.append(
-                osp.join(prop_dir, 'scratch', 'karabo_data_maps', fname)
+                osp.join(prop_dir, 'scratch', '.karabo_data_maps', fname)
             )
 
         self.load()

--- a/karabo_data/run_files_map.py
+++ b/karabo_data/run_files_map.py
@@ -84,7 +84,10 @@ class RunFilesMap:
 
         for info in loaded_data:
             filename = info['filename']
-            st = os.stat(osp.join(self.directory, filename))
+            try:
+                st = os.stat(osp.join(self.directory, filename))
+            except OSError:
+                continue
             if (st.st_mtime == info['mtime']) and (st.st_size == info['size']):
                 self.files_data[filename] = info
 

--- a/karabo_data/run_files_map.py
+++ b/karabo_data/run_files_map.py
@@ -74,7 +74,7 @@ class RunFilesMap:
         """Save the cache if needed
 
         This skips writing the cache out if all the data files already have
-        valid cache entries. It is also silences permission errors from writing
+        valid cache entries. It also silences permission errors from writing
         the cache file.
         """
         need_save = False

--- a/karabo_data/run_files_map.py
+++ b/karabo_data/run_files_map.py
@@ -65,13 +65,15 @@ class RunFilesMap:
         loaded_data = []
 
         for path in self.candidate_paths:
-            if osp.isfile(path):
+            try:
                 with open(path) as f:
                     loaded_data = json.load(f)
 
                 self.cache_file = path
                 log.debug("Loaded cached files map from %s", path)
                 break
+            except (FileNotFoundError, json.JSONDecodeError):
+                pass
 
         for info in loaded_data:
             filename = info['filename']

--- a/karabo_data/run_files_map.py
+++ b/karabo_data/run_files_map.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import os.path as osp
+import numpy as np
 import re
 from tempfile import mkstemp
 import time
@@ -94,7 +95,12 @@ class RunFilesMap:
         """
         dirname, fname = osp.split(osp.abspath(path))
         if (dirname == self.directory) and (fname in self.files_data):
-            return self.files_data[fname]
+            d = self.files_data[fname]
+            return {
+                'train_ids': np.array(d['train_ids'], dtype=np.uint64),
+                'control_sources': frozenset(d['control_sources']),
+                'instrument_sources': frozenset(d['instrument_sources'])
+            }
 
         return None
 

--- a/karabo_data/run_files_map.py
+++ b/karabo_data/run_files_map.py
@@ -1,0 +1,108 @@
+import json
+import logging
+import os
+import os.path as osp
+import re
+
+from .read_machinery import DATA_ROOT_DIR
+
+log = logging.getLogger(__name__)
+
+class RunFilesMap:
+    """Cached data about HDF5 files in a run directory
+
+    Stores the train IDs and source names in each file, along with some
+    metadata to check that the cache is still valid. The cached information
+    can be stored in:
+
+    - (run dir)/karabo_data_map.json
+    - (proposal dir)/scratch/karabo_data_maps/raw_r0032.json
+    """
+    cache_file = None
+
+    def __init__(self, directory):
+        self.directory = osp.abspath(directory)
+        self.files_data = {}
+
+        self.candidate_paths = [osp.join(directory, 'karabo_data_map.json')]
+        m = re.match(
+            r'(%s/\w+/\w+/\w+)/(raw|proc)/(r\d+)/?$' % DATA_ROOT_DIR, directory
+        )
+        if m:
+            prop_dir, raw_proc, run_nr = m.groups()
+            fname = '%s_%s.json' % (raw_proc, run_nr)
+            self.candidate_paths.append(
+                osp.join(prop_dir, 'scratch', 'karabo_data_maps', fname)
+            )
+
+        self.load()
+
+    def load(self):
+        """Load the cached data
+
+        This skips over invalid cache entries(based on the file's size & mtime).
+        """
+        loaded_data = []
+
+        for path in self.candidate_paths:
+            if osp.isfile(path):
+                with open(path) as f:
+                    loaded_data = json.load(f)
+
+                self.cache_file = path
+                log.debug("Loaded cached files map from %s", path)
+                break
+
+        for info in loaded_data:
+            filename = info['filename']
+            st = os.stat(osp.join(self.directory, filename))
+            if (st.st_mtime == info['mtime']) and (st.st_size == info['size']):
+                self.files_data[filename] = info
+
+    def get(self, path):
+        """Get cache entry for a file path
+
+        Returns a dict or None
+        """
+        dirname, fname = osp.split(osp.abspath(path))
+        if (dirname == self.directory) and (fname in self.files_data):
+            return self.files_data[fname]
+
+        return None
+
+    def save(self, files):
+        """Save the cache if needed
+
+        This skips writing the cache out if all the data files already have
+        valid cache entries. It is also silences permission errors from writing
+        the cache file.
+        """
+        need_save = False
+
+        for file_access in files:
+            dirname, fname = osp.split(osp.abspath(file_access.filename))
+            if (dirname == self.directory) and (fname not in self.files_data):
+                log.debug("Will save cached data for %s", fname)
+                need_save = True
+
+                st = os.stat(file_access.filename)
+                self.files_data[fname] = {
+                    'filename': fname,
+                    'mtime': st.st_mtime,
+                    'size': st.st_size,
+                    'train_ids': [int(t) for t in file_access.train_ids],
+                    'control_sources': sorted(file_access.control_sources),
+                    'instrument_sources': sorted(file_access.instrument_sources),
+                }
+
+        if need_save:
+            save_data = [info for (_, info) in sorted(self.files_data.items())]
+            for path in self.candidate_paths:
+                try:
+                    os.makedirs(osp.dirname(path), exist_ok=True)
+                    f = open(path, 'w')
+                except PermissionError:
+                    continue
+
+                with f:
+                    json.dump(save_data, f, indent=2)

--- a/karabo_data/run_files_map.py
+++ b/karabo_data/run_files_map.py
@@ -46,18 +46,22 @@ class RunFilesMap:
         self.directory = osp.abspath(directory)
         self.files_data = {}
 
-        self.candidate_paths = [osp.join(directory, 'karabo_data_map.json')]
+        self.candidate_paths = self.map_paths_for_run(directory)
+
+        self.load()
+
+    def map_paths_for_run(self, directory):
+        paths = [osp.join(directory, 'karabo_data_map.json')]
         m = re.match(
             r'(%s/\w+/\w+/\w+)/(raw|proc)/(r\d+)/?$' % DATA_ROOT_DIR, directory
         )
         if m:
             prop_dir, raw_proc, run_nr = m.groups()
             fname = '%s_%s.json' % (raw_proc, run_nr)
-            self.candidate_paths.append(
+            paths.append(
                 osp.join(prop_dir, 'scratch', '.karabo_data_maps', fname)
             )
-
-        self.load()
+        return paths
 
     def load(self):
         """Load the cached data

--- a/karabo_data/tests/mockdata/mkfile.py
+++ b/karabo_data/tests/mockdata/mkfile.py
@@ -19,3 +19,4 @@ def write_file(filename, devices, ntrains, firsttrain=10000, chunksize=200,
         data_sources.extend(dev.datasource_ids())
     write_metadata(f, data_sources, chunksize=chunksize,
                    format_version=format_version)
+    f.close()

--- a/karabo_data/tests/test_run_files_map.py
+++ b/karabo_data/tests/test_run_files_map.py
@@ -1,7 +1,6 @@
 import h5py
 import mock
 import numpy as np
-import pytest
 
 from karabo_data import run_files_map, RunDirectory
 

--- a/karabo_data/tests/test_run_files_map.py
+++ b/karabo_data/tests/test_run_files_map.py
@@ -1,7 +1,11 @@
 import h5py
 import mock
+import os
 import numpy as np
+import pytest
 
+from .mockdata import write_file
+from .mockdata.xgm import XGM
 from karabo_data import run_files_map, RunDirectory
 
 def test_candidate_paths(mock_fxe_raw_run, tmp_path):
@@ -19,32 +23,44 @@ def test_candidate_paths(mock_fxe_raw_run, tmp_path):
     ]
 
 
-def test_save_load_map(mock_fxe_raw_run, tmp_path):
+@pytest.fixture()
+def run_with_extra_file(mock_fxe_raw_run):
+    extra_file = os.path.join(mock_fxe_raw_run, 'RAW-R0450-DA02-S00000.h5')
+    write_file(extra_file, [
+        XGM('FXE_TEST_XGM/DOOCS/MAIN'),
+    ], ntrains=480)
+    try:
+        yield mock_fxe_raw_run, extra_file
+    finally:
+        os.unlink(extra_file)
+
+
+def test_save_load_map(run_with_extra_file, tmp_path):
+    run_dir, extra_file = run_with_extra_file
     run_map_path = str(tmp_path / 'kd_test_run_map.json')
 
     class TestRunFilesMap(run_files_map.RunFilesMap):
         def map_paths_for_run(self, directory):
             return [run_map_path]
 
-    rfm = TestRunFilesMap(mock_fxe_raw_run)
+    rfm = TestRunFilesMap(run_dir)
     assert rfm.files_data == {}
 
-    with RunDirectory(mock_fxe_raw_run) as run:
+    with RunDirectory(run_dir) as run:
         rfm.save(run.files)
-        filename = run.files[0].filename
 
-    rfm2 = TestRunFilesMap(mock_fxe_raw_run)
+    rfm2 = TestRunFilesMap(run_dir)
     assert rfm2.cache_file == run_map_path
-    file_info = rfm2.get(filename)
+    file_info = rfm2.get(extra_file)
 
     assert isinstance(file_info['train_ids'], np.ndarray)
     assert isinstance(file_info['control_sources'], frozenset)
     assert isinstance(file_info['instrument_sources'], frozenset)
 
     # Modify a file; this should make the cache invalid
-    with h5py.File(filename, 'r+') as f:
+    with h5py.File(extra_file, 'r+') as f:
         f.attrs['test_save_load_map'] = 1
 
-    rfm3 = TestRunFilesMap(mock_fxe_raw_run)
+    rfm3 = TestRunFilesMap(run_dir)
     assert rfm3.cache_file == run_map_path
-    assert rfm3.get(filename) is None
+    assert rfm3.get(extra_file) is None

--- a/karabo_data/tests/test_run_files_map.py
+++ b/karabo_data/tests/test_run_files_map.py
@@ -1,0 +1,51 @@
+import h5py
+import mock
+import numpy as np
+import pytest
+
+from karabo_data import run_files_map, RunDirectory
+
+def test_candidate_paths(mock_fxe_raw_run, tmp_path):
+    prop_path = tmp_path / 'FXE' / '201901' / 'p001234'
+    run_path = prop_path / 'raw' / 'r0450'
+    run_path.parent.mkdir(parents=True)
+    run_path.symlink_to(mock_fxe_raw_run)
+
+    with mock.patch.object(run_files_map, 'DATA_ROOT_DIR', str(tmp_path)):
+        rfm = run_files_map.RunFilesMap(str(run_path))
+
+    assert rfm.candidate_paths == [
+        str(run_path / 'karabo_data_map.json'),
+        str(prop_path / 'scratch' / '.karabo_data_maps' / 'raw_r0450.json'),
+    ]
+
+
+def test_save_load_map(mock_fxe_raw_run, tmp_path):
+    run_map_path = str(tmp_path / 'kd_test_run_map.json')
+
+    class TestRunFilesMap(run_files_map.RunFilesMap):
+        def map_paths_for_run(self, directory):
+            return [run_map_path]
+
+    rfm = TestRunFilesMap(mock_fxe_raw_run)
+    assert rfm.files_data == {}
+
+    with RunDirectory(mock_fxe_raw_run) as run:
+        rfm.save(run.files)
+        filename = run.files[0].filename
+
+    rfm2 = TestRunFilesMap(mock_fxe_raw_run)
+    assert rfm2.cache_file == run_map_path
+    file_info = rfm2.get(filename)
+
+    assert isinstance(file_info['train_ids'], np.ndarray)
+    assert isinstance(file_info['control_sources'], frozenset)
+    assert isinstance(file_info['instrument_sources'], frozenset)
+
+    # Modify a file; this should make the cache invalid
+    with h5py.File(filename, 'r+') as f:
+        f.attrs['test_save_load_map'] = 1
+
+    rfm3 = TestRunFilesMap(mock_fxe_raw_run)
+    assert rfm3.cache_file == run_map_path
+    assert rfm3.get(filename) is None

--- a/karabo_data/validation.py
+++ b/karabo_data/validation.py
@@ -126,7 +126,7 @@ class RunValidator:
 
         for path in glob(os.path.join(run_dir, '*.h5')):
             try:
-                fa = FileAccess(h5py.File(path, 'r'))
+                fa = FileAccess(path)
             except Exception as e:
                 self.files_excluded.append((path, e))
             else:

--- a/karabo_data/validation.py
+++ b/karabo_data/validation.py
@@ -171,7 +171,7 @@ class RunValidator:
             if (
                     f_cache['control_sources'] != f_access.control_sources
                  or f_cache['instrument_sources'] != f_access.instrument_sources
-                 or f_cache['train_ids'] != f_access.train_ids
+                 or not np.array_equal(f_cache['train_ids'], f_access.train_ids)
             ):
                 self.problems.append(dict(
                     msg="Incorrect data map cache entry",


### PR DESCRIPTION
Opening a run is slow: we read a little bit of data from each file to know what sources and trains are in that file. This appears to be especially bad if the files are not already cached on that node: it seems like gpfs moves big chunks of data around. But it's slow even when the data is cached locally.

Testing with `lsxfel /gpfs/exfel/exp/SCS/201901/p002212/raw/r0070` (~400 files, 1.7 TB) , I got roughly:

- 4 minutes worst case when gpfs has to transfer data onto the node
- 21 seconds reading data from each file when they've already been cached locally
- 1.6 seconds with the cache file implemented in the first commit here
- 1.4 seconds with the cache file plus lazy opening of HDF5 files (second commit)

I was hoping that lazy opening would give a further substantial speedup. It doesn't seem to, so I might still revert it. But I want to test more if it makes a difference when files are not cached locally.

The worst case is unchanged: if the cache file isn't there it still reads metadata from each file. But hopefully that only needs to happen once. Multiple users can share the cache file - it just needs someone with write access to the proposal's scratch dir to create it.