### PR TITLE
Delay some imports to where they are used

### DIFF
--- a/docs/streaming.rst
+++ b/docs/streaming.rst
@@ -18,7 +18,7 @@ We provide Karabo bridge clients as Python and C++ libraries.
 If you want to do some processing on the data before streaming it, you can
 use this Python interface to send it out:
 
-.. currentmodule:: karabo_data
+.. module:: karabo_data.export
 
 .. autoclass:: ZMQStreamer
 

--- a/karabo_data/__init__.py
+++ b/karabo_data/__init__.py
@@ -35,11 +35,28 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 
 __version__ = "0.6.2"
 
+from warnings import warn
 
 from .reader import *
 from .stacking import *
-from .export import *
 from .utils import *
 
+def ZMQStreamer(port, maxlen=10, protocol_version='2.2', dummy_timestamps=False):
+    warn("Please update imports: "
+         "karabo_data.ZMQStreamer -> karabo_data.export.ZMQStreamer",
+         UserWarning, stacklevel=2)
+    from . import export
+    return export.ZMQStreamer(
+        port=port, maxlen=maxlen, protocol_version=protocol_version, dummy_timestamps=dummy_timestamps
+    )
 
-__all__ = export.__all__ + reader.__all__ + utils.__all__ + stacking.__all__
+def serve_files(path, port, source_glob='*', key_glob='*', **kwargs):
+    warn("Please update imports: "
+         "karabo_data.serve_files -> karabo_data.export.serve_files",
+         UserWarning, stacklevel=2)
+    from . import export
+    return export.serve_files(
+        path=path, port=port, source_glob=source_glob, key_glob=key_glob, **kwargs
+    )
+
+__all__ = reader.__all__ + utils.__all__ + stacking.__all__ + ['ZMQStreamer', 'serve_files']

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -19,11 +19,9 @@ import logging
 import numpy as np
 import os
 import os.path as osp
-import pandas as pd
 import re
 import sys
 import tempfile
-import xarray
 
 from .exceptions import SourceNameError, PropertyNameError, TrainIDError
 from .read_machinery import (
@@ -456,6 +454,8 @@ class DataCollection:
 
         Returns a pandas series with an index of train IDs.
         """
+        import pandas as pd
+
         self._check_field(source, key)
         seq_series = []
 
@@ -491,6 +491,8 @@ class DataCollection:
             Key of parameter within that device, e.g. "beamPosition.iyPos.value"
             or "header.linkId". The data must be 1D in the file.
         """
+        import pandas as pd
+
         self._check_field(source, key)
         name = source + '/' + key
         if name.endswith('.value'):
@@ -564,6 +566,8 @@ class DataCollection:
             If false (the default), exclude the timestamps associated with each
             control data field.
         """
+        import pandas as pd
+
         if fields is not None:
             return self.select(fields).get_dataframe(timestamps=timestamps)
 
@@ -606,6 +610,8 @@ class DataCollection:
             first 8 values from every train. If the data is 2D or more at
             each entry, selection looks like roi=by_index[:8, 5:10] .
         """
+        import xarray
+
         self._check_field(source, key)
 
         if not isinstance(roi, by_index):

--- a/karabo_data/tests/test_streamer.py
+++ b/karabo_data/tests/test_streamer.py
@@ -5,12 +5,10 @@ import msgpack_numpy as numpack
 import numpy as np
 import pytest
 from queue import Full
-from struct import pack
-from time import sleep
 
 from karabo_bridge import Client
 
-from karabo_data import ZMQStreamer
+from karabo_data.export import ZMQStreamer
 
 DATA = {
     'source1': {

--- a/karabo_data/utils.py
+++ b/karabo_data/utils.py
@@ -8,7 +8,6 @@ You should have received a copy of the 3-Clause BSD License along with this
 program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 """
 
-import fabio
 import h5py
 import numpy as np
 
@@ -128,6 +127,7 @@ def hdf5_paths(ds, indent=0, maxlen=100):
 
 def numpy_to_cbf(np_array, index=0, header=None):
     """Given a 3D numpy array, convert it to a CBF data object"""
+    import fabio.cbfimage
     img_reduced = np_array[index, ...]
     return fabio.cbfimage.cbfimage(header=header or {}, data=img_reduced)
 


### PR DESCRIPTION
This speeds up import by 50-70% in my tests (from ~1s to 0.3-0.5s). Pandas and xarray in particular both import many files, so there's a big benefit if we can avoid them.

Of course, you still have to import those packages if you want to use their data formats. But we don't for `lsxfel`, so this significantly improves overall performance (in combination with #206).