### PR TITLE
Avoid memory copy in get_array

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -629,24 +629,29 @@ class DataCollection:
 
         # Figure out the shape of the result array, and the slice for each chunk
         dest_dim0 = 0
-        shapes = set()
         dest_slices = []
+        shapes = set()
+        dtypes = set()
 
         for chunk in chunks:
             n = int(np.sum(chunk.counts, dtype=np.uint64))
             dest_slices.append(slice(dest_dim0, dest_dim0 + n))
             dest_dim0 += n
             shapes.add(chunk.dataset.shape[1:])
+            dtypes.add(chunk.dataset.dtype)
 
         if len(shapes) > 1:
             raise Exception("Mismatched data shapes: {}".format(shapes))
+
+        if len(dtypes) > 1:
+            raise Exception("Mismatched dtypes: {}".format(dtypes))
 
         # Find the shape of the array with the ROI applied
         roi_dummy = np.zeros((0,) + shapes.pop()) # extra 0 dim: use less memory
         roi_shape = roi_dummy[np.index_exp[:] + roi].shape[1:]
 
         chunks_trainids = []
-        res = np.empty((dest_dim0,) + roi_shape)
+        res = np.empty((dest_dim0,) + roi_shape, dtype=dtypes.pop())
 
         # Read the data from each chunk into the result array
         for chunk, dest_slice in zip(chunks, dest_slices):


### PR DESCRIPTION
`get_array()` previously worked by getting a numpy array for each chunk of data (e.g. each file) and then concatenating them together, which involves a memory copy. This change makes it work out the shape first, create a numpy array of the desired size, and read the data directly into that.

Tests with ~3 MB of XGM data spread across 7 files show about a 50% speed-up with a warm cache (48 ms -> 24 ms). Presumably, if the data is cached in OS memory, this reflects that it's being copied once rather than twice.

Obviously the speed up will be much smaller in most real use cases when you're getting data that's not already cached. But it could also reduce memory pressure with large amounts of data - the previous implementation would briefly need twice as much memory.