### PR TITLE
Permission error

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1205,12 +1205,12 @@ def RunDirectory(path):
     path: str
         Path to the run directory containing HDF5 files.
     """
-    if not os.access(path, os.R_OK):
-        username = pwd.getpwuid(os.geteuid()).pw_name
-        raise PermissionError(
-                  "Permission denied for '{}': {}".format(username, path))
     files = glob(osp.join(path, '*.h5'))
     if not files:
+        if osp.isdir(path) and not os.access(path, os.R_OK):
+            username = pwd.getpwuid(os.geteuid()).pw_name
+            raise PermissionError(
+                    "Permission denied for '{}': {}".format(username, path))
         raise Exception("No HDF5 files found in {}".format(path))
     return DataCollection.from_paths(files)
 

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -17,7 +17,6 @@ from glob import glob
 import logging
 import os
 import os.path as osp
-import pwd
 import re
 import sys
 import tempfile
@@ -1205,12 +1204,8 @@ def RunDirectory(path):
     path: str
         Path to the run directory containing HDF5 files.
     """
-    files = glob(osp.join(path, '*.h5'))
+    files = [osp.join(path, f) for f in os.listdir(path) if f.endswith('.h5')]
     if not files:
-        if osp.isdir(path) and not os.access(path, os.R_OK):
-            username = pwd.getpwuid(os.geteuid()).pw_name
-            raise PermissionError(
-                    "Permission denied for '{}': {}".format(username, path))
         raise Exception("No HDF5 files found in {}".format(path))
     return DataCollection.from_paths(files)
 

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -14,15 +14,17 @@ from collections import defaultdict
 import datetime
 import fnmatch
 from glob import glob
-import h5py
 import logging
-import numpy as np
 import os
 import os.path as osp
-import pandas as pd
+import pwd
 import re
 import sys
 import tempfile
+
+import h5py
+import numpy as np
+import pandas as pd
 import xarray
 
 from .exceptions import SourceNameError, PropertyNameError, TrainIDError
@@ -1203,6 +1205,10 @@ def RunDirectory(path):
     path: str
         Path to the run directory containing HDF5 files.
     """
+    if not os.access(path, os.R_OK):
+        username = pwd.getpwuid(os.geteuid()).pw_name
+        raise PermissionError(
+                  "Permission denied for '{}': {}".format(username, path))
     files = glob(osp.join(path, '*.h5'))
     if not files:
         raise Exception("No HDF5 files found in {}".format(path))

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -14,17 +14,14 @@ from collections import defaultdict
 import datetime
 import fnmatch
 from glob import glob
+import h5py
 import logging
+import numpy as np
 import os
 import os.path as osp
 import re
 import sys
 import tempfile
-
-import h5py
-import numpy as np
-import pandas as pd
-import xarray
 
 from .exceptions import SourceNameError, PropertyNameError, TrainIDError
 from .read_machinery import (

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -5,6 +5,8 @@ import numpy as np
 import os
 import pandas as pd
 import pytest
+import stat
+from tempfile import mkdtemp
 from testpath import assert_isfile
 from unittest import mock
 from xarray import DataArray
@@ -560,8 +562,18 @@ def test_open_file_format_0_5(mock_sa3_control_data):
     assert file_access.format_version == '0.5'
     assert 'SA3_XTD10_VAC/TSENS/S30180K' in f.control_sources
 
+
 def test_open_file_format_1_0(mock_sa3_control_data_fmt_1_0):
     f = H5File(mock_sa3_control_data_fmt_1_0)
     file_access = f.files[0]
     assert file_access.format_version == '1.0'
     assert 'SA3_XTD10_VAC/TSENS/S30180K' in f.control_sources
+
+
+def test_permission():
+    d = mkdtemp()
+    os.chmod(d, not stat.S_IRUSR)
+    with pytest.raises(PermissionError) as excinfo:
+        run = RunDirectory(d)
+    assert "Permission denied" in str(excinfo.value)
+    assert d in str(excinfo.value)


### PR DESCRIPTION
Opening a run with `RunDirectory` or `open_run` where the user does not have read access would result in a "No HDF5 files found" exception and I find that misleading.

It would now raise a `PermissionError` in such case.