### PR TITLE
Validate index dataset size

### DIFF
--- a/karabo_data/validation.py
+++ b/karabo_data/validation.py
@@ -89,7 +89,30 @@ class FileValidator:
 
             for src, group in src_groups:
                 record = partial(self.record, dataset='INDEX/{}/{}'.format(src, group))
-                first, count = self.file._read_index(src, group)
+                first, count = self.file.get_index(src, group)
+
+                if (first.ndim != 1) or (count.ndim != 1):
+                    record(
+                        "Index first / count are not 1D",
+                        first_shape=first.shape,
+                        count_shape=count.shape,
+                    )
+                    continue
+
+                if first.shape != count.shape:
+                    record(
+                        "Index first & count have different number of entries",
+                        first_shape=first.shape,
+                        count_shape=count.shape,
+                    )
+
+                if first.shape != self.file.train_ids.shape:
+                    record(
+                        "Index has wrong number of entries",
+                        index_shape=first.shape,
+                        trainids_shape=self.file.train_ids.shape,
+                    )
+
                 check_index_contiguous(first, count, record)
 
 


### PR DESCRIPTION
@RobertRosca was having problems with a run directory - I looked into it and found that some of the indexes had fewer entries than the train IDs. As far as I know, this is not meant to happen, so this adds a check for that (along with a couple of other scenarios which we haven't seen, but which would definitely cause problems if they did).

```
$ karabo-data-validate /gpfs/exfel/exp/SPB/201802/p002157/proc/r0045
...
Index has wrong number of entries
  dataset: INDEX/SPB_DET_AGIPD1M-1/DET/11CH0:xtdf/image
  file: ./CORR-R0045-AGIPD11-S00000.h5
  index_shape: (119,)
  trainids_shape: (256,)
```