### PR TITLE
Add quickstart to docs home page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,13 @@
-Karabo Python data tools
-========================
+European XFEL Python data tools
+===============================
 
 **karabo_data** is a Python library for accessing and working with data
 produced at `European XFEL <https://www.xfel.eu/>`_.
-It is available on our Anaconda installation on the Maxwell cluster::
+
+Installation
+------------
+
+karabo_data is available on our Anaconda installation on the Maxwell cluster::
 
     module load exfel exfel_anaconda3
 
@@ -14,7 +18,48 @@ to use in other environments with Python 3.5 or later::
 
 If you get a permissions error, add the ``--user`` flag to that command.
 
-Contents:
+Quickstart
+----------
+
+Open a run or a file - see :ref:`opening-files` for more::
+
+    from karabo_data import open_run, RunDirectory, H5File
+
+    # Find a run on the Maxwell cluster
+    run = open_run(proposal=700000, run=1)
+
+    # Open a run with a directory path
+    run = RunDirectory("/gpfs/exfel/exp/XMPL/201750/p700000/raw/r0001")
+
+    # Open an individual file
+    file = H5File("RAW-R0017-DA01-S00000.h5")
+
+After this step, you'll use the same methods to get data whether you opened a
+run or a file.
+
+Load data into memory - see :ref:`data-by-source-and-key` for more::
+
+    # Get a labelled array
+    run.get_array("SA3_XTD10_PES/ADC/1:network", "digitizers.channel_4_A.raw.samples")
+
+    # Get a pandas dataframe of 1D fields
+    df = run.get_dataframe(fields=[
+        ("*_XGM/*", "*.i[xy]Pos"),
+        ("*_XGM/*", "*.photonFlux")
+    ])
+
+Iterate through data for each pulse train - see :ref:`data-by-train` for more::
+
+    for train_id, data in run.select("*/DET/*", "image.data").trains():
+        mod0 = data["FXE_DET_LPD1M-1/DET/0CH0:xtdf"]["image.data"]
+
+These are not the only ways to get data: :doc:`reading_files` describes
+various other options.
+karabo_data also has classes to work with detector geometry,
+described in :doc:`geometry`.
+
+Documentation contents
+----------------------
 
 .. toctree::
    :maxdepth: 2

--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -1,6 +1,8 @@
 Reading data files
 ==================
 
+.. _opening-files:
+
 Opening files
 -------------
 
@@ -64,6 +66,8 @@ to refer to all data associated with that 0.1 second window.
 
    .. automethod:: info
 
+.. _data-by-source-and-key:
+
 Getting data by source & key
 ----------------------------
 
@@ -93,6 +97,8 @@ to load it like this.
    .. automethod:: get_virtual_dataset
 
       .. versionadded:: 0.5
+
+.. _data-by-train:
 
 Getting data by train
 ---------------------


### PR DESCRIPTION
Showing only the most fundamental things karabo_data can do.

I have a small reservation about this, that once there's a quickstart no-one will ever look beyond it to see anything else karabo_data can do. On the other hand, I think hardly anyone looks at the more detailed documentation anyway, so having a short summary might get people started more usefully. And I've tried to integrate links to take people into the detailed documentation.

cc @RobertRosca - this relates to what you were saying this morning, that people don't know about loading individual files.