### PR TITLE
Check all symlinks to a run directory

### DIFF
--- a/karabo_data/run_files_map.py
+++ b/karabo_data/run_files_map.py
@@ -65,6 +65,7 @@ class RunFilesMap:
         self.load()
 
     def map_paths_for_run(self, directory):
+        directory = osp.abspath(directory)
         paths = [osp.join(directory, 'karabo_data_map.json')]
 
         candidate_links = [directory] + follow_symlinks(directory)
@@ -78,7 +79,7 @@ class RunFilesMap:
                     osp.join(prop_dir, 'scratch', '.karabo_data_maps', fname)
                 )
                 return osp.abspath(l), paths
-        return osp.abspath(directory), paths
+        return directory, paths
 
     def load(self):
         """Load the cached data

--- a/karabo_data/tests/test_run_files_map.py
+++ b/karabo_data/tests/test_run_files_map.py
@@ -41,7 +41,7 @@ def test_save_load_map(run_with_extra_file, tmp_path):
 
     class TestRunFilesMap(run_files_map.RunFilesMap):
         def map_paths_for_run(self, directory):
-            return [run_map_path]
+            return directory, [run_map_path]
 
     rfm = TestRunFilesMap(run_dir)
     assert rfm.files_data == {}


### PR DESCRIPTION
Check all symlinks from a given path against the rundir regex for cache path candidates.

This should solve the symlink issue @takluyver mentioned in https://github.com/European-XFEL/karabo_data/pull/206#issuecomment-543699134_

I had a few tries with random nested symlinks and it works so far, ex:
```
lrwxrwxrwx  1 tmichela exfel       34 Oct 21 14:52 p002212 -> /gpfs/exfel/exp/SCS/201901/p002212
lrwxrwxrwx  1 tmichela exfel       15 Oct 21 17:13 p002212plop -> ./p002212random
lrwxrwxrwx  1 tmichela exfel       25 Oct 21 16:52 p002212random -> /home/tmichela/p002212raw
lrwxrwxrwx  1 tmichela exfel       38 Oct 21 15:24 p002212raw -> /gpfs/exfel/exp/SCS/201901/p002212/raw
```

running `follow_symlinks` on these will return:
```
path: ./p002212
links: ['/gpfs/exfel/exp/SCS/201901/p002212']

path: ./p002212raw
links: ['/gpfs/exfel/d/raw/SCS/201901/p002212', '/gpfs/exfel/exp/SCS/201901/p002212/raw']

path: ./p002212/raw/r0012
links: ['/gpfs/exfel/exp/SCS/201901/p002212', '/gpfs/exfel/d/raw/SCS/201901/p002212']

path: ./p002212raw/r0012
links: ['/gpfs/exfel/d/raw/SCS/201901/p002212', '/gpfs/exfel/exp/SCS/201901/p002212/raw']

path: ./p002212random
links: ['/gpfs/exfel/d/raw/SCS/201901/p002212', '/gpfs/exfel/exp/SCS/201901/p002212/raw', '/home/tmichela/p002212raw']

path: /home/tmichela/p002212plop
links: ['/gpfs/exfel/d/raw/SCS/201901/p002212', '/gpfs/exfel/exp/SCS/201901/p002212/raw', '/home/tmichela/p002212raw', './p002212random']

```

