### PR TITLE
 Add a simple filter interface to RunDirectory 

### DIFF
--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1277,7 +1277,7 @@ def H5File(path):
     return DataCollection.from_path(path)
 
 
-def RunDirectory(path):
+def RunDirectory(path, include=None, exclude=None):
     """Open data files from a 'run' at European XFEL.
 
     ::
@@ -1293,8 +1293,16 @@ def RunDirectory(path):
     ----------
     path: str
         Path to the run directory containing HDF5 files.
+    include: str or None
+        Only open data files of which "include" is a substring.
+    exclude: str or None
+        Skip data files that have "exclude" in their filename.
     """
     files = [osp.join(path, f) for f in os.listdir(path) if f.endswith('.h5')]
+    if include is not None:
+        files = [f for f in files if f in include]
+    if exclude is not None:
+        files = [f for f in files if f not in exclude]
     if not files:
         raise Exception("No HDF5 files found in {}".format(path))
     return DataCollection.from_paths(files)

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1296,10 +1296,10 @@ def RunDirectory(path, include='*'):
     include: str
         Wildcard string to filter data files.
     """
-    files = [osp.join(path, f) for f in os.listdir(path) if f.endswith('.h5')]
-    files = fnmatch.filter(files, include)
+    files = [f for f in os.listdir(path) if f.endswith('.h5')]
+    files = [osp.join(path, f) for f in fnmatch.filter(files, include)]
     if not files:
-        raise Exception("No HDF5 files found in {}".format(path))
+        raise Exception("No HDF5 files found in {} with glob pattern {}".format(path, include))
     return DataCollection.from_paths(files)
 
 

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1313,7 +1313,7 @@ def RunDirectory(path, include=None, exclude=None):
 RunHandler = RunDirectory
 
 
-def open_run(proposal, run, data='raw'):
+def open_run(proposal, run, data='raw', include=None, exclude=None):
     """Access EuXFEL data on the Maxwell cluster by proposal and run number.
 
     ::
@@ -1332,6 +1332,10 @@ def open_run(proposal, run, data='raw'):
     data: str
         'raw' or 'proc' (processed) to access data from one of those folders.
         The default is 'raw'.
+    include: str or None
+        If not None, only open data files of which "include" is a substring.
+    exclude: str or None
+        If not None, skip data files that have "exclude" in their filename.
     """
     if isinstance(proposal, int):
         proposal = 'p{:06d}'.format(proposal)
@@ -1345,4 +1349,4 @@ def open_run(proposal, run, data='raw'):
     elif not run.startswith('r'):
         run = 'r' + run.rjust(4, '0')
 
-    return RunDirectory(osp.join(prop_dir, data, run))
+    return RunDirectory(osp.join(prop_dir, data, run), include=include, exclude=exclude)

--- a/karabo_data/reader.py
+++ b/karabo_data/reader.py
@@ -1277,7 +1277,7 @@ def H5File(path):
     return DataCollection.from_path(path)
 
 
-def RunDirectory(path, include=None, exclude=None):
+def RunDirectory(path, include='*'):
     """Open data files from a 'run' at European XFEL.
 
     ::
@@ -1293,16 +1293,11 @@ def RunDirectory(path, include=None, exclude=None):
     ----------
     path: str
         Path to the run directory containing HDF5 files.
-    include: str or None
-        Only open data files of which "include" is a substring.
-    exclude: str or None
-        Skip data files that have "exclude" in their filename.
+    include: str
+        Wildcard string to filter data files.
     """
     files = [osp.join(path, f) for f in os.listdir(path) if f.endswith('.h5')]
-    if include is not None:
-        files = [f for f in files if f in include]
-    if exclude is not None:
-        files = [f for f in files if f not in exclude]
+    files = fnmatch.filter(files, include)
     if not files:
         raise Exception("No HDF5 files found in {}".format(path))
     return DataCollection.from_paths(files)
@@ -1313,7 +1308,7 @@ def RunDirectory(path, include=None, exclude=None):
 RunHandler = RunDirectory
 
 
-def open_run(proposal, run, data='raw', include=None, exclude=None):
+def open_run(proposal, run, data='raw', include='*'):
     """Access EuXFEL data on the Maxwell cluster by proposal and run number.
 
     ::
@@ -1332,10 +1327,8 @@ def open_run(proposal, run, data='raw', include=None, exclude=None):
     data: str
         'raw' or 'proc' (processed) to access data from one of those folders.
         The default is 'raw'.
-    include: str or None
-        If not None, only open data files of which "include" is a substring.
-    exclude: str or None
-        If not None, skip data files that have "exclude" in their filename.
+    include: str
+        Wildcard string to filter data files.
     """
     if isinstance(proposal, int):
         proposal = 'p{:06d}'.format(proposal)
@@ -1349,4 +1342,4 @@ def open_run(proposal, run, data='raw', include=None, exclude=None):
     elif not run.startswith('r'):
         run = 'r' + run.rjust(4, '0')
 
-    return RunDirectory(osp.join(prop_dir, data, run), include=include, exclude=exclude)
+    return RunDirectory(osp.join(prop_dir, data, run), include=include)

--- a/karabo_data/tests/test_reader_mockdata.py
+++ b/karabo_data/tests/test_reader_mockdata.py
@@ -118,6 +118,16 @@ def test_read_fxe_raw_run(mock_fxe_raw_run):
     assert run.train_ids == list(range(10000, 10480))
     run.info()  # Smoke test
 
+def test_read_fxe_raw_run_selective(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run, include='*DA*')
+    assert run.train_ids == list(range(10000, 10480))
+    assert 'SA1_XTD2_XGM/DOOCS/MAIN' in run.control_sources
+    assert 'FXE_DET_LPD1M-1/DET/0CH0:xtdf' not in run.detector_sources
+    run = RunDirectory(mock_fxe_raw_run, include='*LPD*')
+    assert run.train_ids == list(range(10000, 10480))
+    assert 'SA1_XTD2_XGM/DOOCS/MAIN' not in run.control_sources
+    assert 'FXE_DET_LPD1M-1/DET/0CH0:xtdf' in run.detector_sources
+
 def test_read_spb_proc_run(mock_spb_proc_run):
     run = RunDirectory(mock_spb_proc_run) #Test for calib data
     assert len(run.files) == 16 # only 16 detector modules for calib data


### PR DESCRIPTION
Hi all,

opening the RunDirectory can take a significant amount of time for long runs with many sources. I often find that I only need a (known) subset of the DAQ files, in which case much of that time can be saved.

Examples:
- When setting up a distributed process for DSSC files, I'm only interested in non-DSSC data, so I'd use
run = RunDirectory(path, exlude='DSSC'). Typically, this brings down the load time from ~5 minutes to less than 20 seconds... In an interactive session this is a huge benefit to me.
- When processing the actual DSSC data, I parallelize over the different modules. In each subprocess I do run = RunDirectory(path, include=f'DSSC{module_nr:02d}'. This also makes sure that no file access conflicts arise when several subprocesses try to index the same files.

The proposed change gives this functionality. Of course this could be generalized by passing a filter function, but I actually think this very simple implementation is sufficient and easier to use (though I'd be happy with the filter function approach as well).

What do you think?

Cheers,

Michael
